### PR TITLE
Stability phase 1: examples, docs, types, version sync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,5 +27,6 @@ jobs:
       - run: cd ts && npm install --ignore-scripts
       - run: cd ts && npm run lint
       - run: cd ts && npm run format:check
+      - run: cd ts && npm run check:examples
       - run: cd ts && npm run build
       - run: cd ts && npm test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,3 +164,25 @@ jobs:
           gh release create "$GITHUB_REF_NAME" \
             --title "$GITHUB_REF_NAME" \
             --generate-notes
+
+      - name: Sync versions back to main
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          git checkout main
+          git pull --ff-only origin main
+          MAIN_VERSION=$(node -p "require('./ts/package.json').version")
+          if npx semver "$VERSION" -r ">=${MAIN_VERSION}"; then
+            cd ts && npm version "${VERSION}" --no-git-tag-version --allow-same-version && cd ..
+            node scripts/sync-versions.mjs
+            if git diff --quiet; then
+              echo "Versions already in sync"
+            else
+              git add ts/package.json npm/*/package.json
+              git commit -m "Sync package versions to ${VERSION}"
+              git push origin main
+            fi
+          else
+            echo "Skipping sync: released ${VERSION} is older than main (${MAIN_VERSION})"
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -179,9 +179,12 @@ When adding wrappers, move methods from `excluded` -> `wrapped` and keep priorit
 
 1. Bump version in `ts/package.json`
 2. Run `node scripts/sync-versions.mjs` to sync all platform packages
-3. Commit and tag: `git tag v0.2.0`
-4. Push tag: `git push origin v0.2.0`
-5. CI handles the rest (build, publish, GitHub release)
+3. Commit: `git add ts/package.json npm/*/package.json && git commit -m "Bump to 0.5.0"`
+4. Tag: `git tag v0.5.0`
+5. Push both: `git push origin main v0.5.0`
+6. CI handles the rest (build, publish, GitHub release, version sync commit)
+
+**Important:** Always commit the synced versions _before_ tagging so that `main` is never behind the published version. The release workflow also commits synced versions back to `main` as a safety net, but the source should already be in sync.
 
 ## Version Syncing
 
@@ -189,4 +192,4 @@ The `scripts/sync-versions.mjs` script reads the version from `ts/package.json` 
 - All `npm/*/package.json` platform packages
 - The `optionalDependencies` in `ts/package.json`
 
-The release workflow also does this automatically from the git tag.
+Run it after bumping `ts/package.json` and commit the result. The release workflow runs it again as a safety net and commits back to `main` if anything drifted.

--- a/README.md
+++ b/README.md
@@ -107,6 +107,181 @@ if (!jid) {
 await client.connect();
 ```
 
+## Connection Lifecycle
+
+The connection flow follows a specific sequence:
+
+```
+init() → connect() → "connected" event → operational → "disconnected" → auto-reconnect → "connected"
+```
+
+**Normal startup:**
+
+```typescript
+const { jid } = await client.init();  // Opens store, returns JID if already paired
+if (!jid) {
+  await client.getQRChannel();        // Set up QR pairing (first time only)
+}
+await client.connect();               // Starts connection (async, returns immediately)
+// Wait for "connected" event before sending messages
+```
+
+**Key events:**
+
+| Event | Meaning | Action |
+|-------|---------|--------|
+| `connected` | WhatsApp connection established | Safe to send messages |
+| `disconnected` | Connection lost | Auto-reconnect is built-in, no action needed |
+| `logged_out` | Session revoked (user unlinked device) | Must re-pair — delete store and start over |
+| `stream_error` | Protocol error from WhatsApp | Usually followed by auto-reconnect |
+| `keep_alive_timeout` | Keep-alive pings failing | Connection may be degraded |
+| `keep_alive_restored` | Keep-alive recovered | Connection is healthy again |
+
+**Resilient connection pattern:**
+
+```typescript
+const client = createClient({ store: "session.db" });
+
+client.on("connected", ({ jid }) => {
+  console.log(`Connected as ${jid}`);
+});
+
+client.on("disconnected", () => {
+  console.log("Disconnected — waiting for auto-reconnect...");
+});
+
+client.on("logged_out", ({ reason }) => {
+  console.error(`Logged out: ${reason}. Must re-pair.`);
+  process.exit(1);
+});
+
+const { jid } = await client.init();
+if (!jid) {
+  await client.getQRChannel();
+  client.on("qr", ({ code }) => {
+    // Render QR code for pairing
+  });
+}
+await client.connect();
+```
+
+Auto-reconnect is always enabled — whatsmeow handles reconnection internally. You only need to handle `logged_out` (session revoked, must re-pair).
+
+## Error Handling
+
+All client methods throw on failure. Errors are typed for easy handling:
+
+```typescript
+import {
+  WhatsmeowError,    // Base class for all whatsmeow errors
+  TimeoutError,      // IPC command timed out
+  ProcessExitedError // Go binary crashed or exited
+} from "@whatsmeow-node/whatsmeow-node";
+
+try {
+  await client.sendMessage(jid, { conversation: "hello" });
+} catch (err) {
+  if (err instanceof WhatsmeowError) {
+    console.error(`WhatsApp error [${err.code}]: ${err.message}`);
+  }
+}
+```
+
+**Common error codes:**
+
+| Code | Source | Meaning |
+|------|--------|---------|
+| `ERR_TIMEOUT` | TS | IPC command timed out (default: 30s) |
+| `ERR_PROCESS_EXITED` | TS | Go binary crashed or exited |
+| `ERR_NOT_INIT` | Go | `init()` not called yet |
+| `ERR_INVALID_ARGS` | Go | Missing or invalid arguments |
+| `ERR_INVALID_JID` | Go | Malformed JID string |
+| `ERR_SEND` | Go | Message send failed |
+| `ERR_UPLOAD` | Go | Media upload failed |
+| `ERR_UNKNOWN_CMD` | Go | Unrecognized IPC command |
+
+**Pattern for handling specific errors:**
+
+```typescript
+try {
+  await client.sendMessage(jid, { conversation: "hello" });
+} catch (err) {
+  if (err instanceof WhatsmeowError) {
+    switch (err.code) {
+      case "ERR_SEND":
+        console.error("Message failed:", err.message);
+        break;
+      case "ERR_NOT_INIT":
+        console.error("Forgot to call init()");
+        break;
+      default:
+        throw err;
+    }
+  }
+}
+```
+
+## Sending Messages
+
+**Text message:**
+
+```typescript
+await client.sendMessage(jid, { conversation: "Hello!" });
+```
+
+**Reply to a message:**
+
+```typescript
+await client.sendMessage(jid, {
+  extendedTextMessage: {
+    text: "This is a reply",
+    contextInfo: {
+      stanzaId: originalMessageId,
+      participant: originalSenderJid,
+      quotedMessage: { conversation: "the original text" },
+    },
+  },
+});
+```
+
+**Image, location, contact card** (use `sendRawMessage` for any proto shape):
+
+```typescript
+// Upload then send an image
+const media = await client.uploadMedia("/path/to/photo.jpg", "image");
+await client.sendRawMessage(jid, {
+  imageMessage: {
+    url: media.url,
+    directPath: media.directPath,
+    mediaKey: media.mediaKey,
+    fileEncSha256: media.fileEncSha256,
+    fileSha256: media.fileSha256,
+    fileLength: String(media.fileLength),
+    mimetype: "image/jpeg",
+    caption: "Check this out",
+  },
+});
+
+// Send a location
+await client.sendRawMessage(jid, {
+  locationMessage: {
+    degreesLatitude: -34.9011,
+    degreesLongitude: -56.1645,
+    name: "Montevideo",
+  },
+});
+
+// Send a contact card
+await client.sendRawMessage(jid, {
+  contactMessage: {
+    displayName: "John Doe",
+    vcard: "BEGIN:VCARD\nVERSION:3.0\nFN:John Doe\nTEL:+1234567890\nEND:VCARD",
+  },
+});
+```
+
+`sendRawMessage` accepts any `Record<string, unknown>` matching the [whatsmeow `waE2E.Message` proto schema](https://pkg.go.dev/go.mau.fi/whatsmeow/proto/waE2E#Message). The JSON shape uses protojson field names (camelCase).
+
 ## API
 
 ### `createClient(options)`

--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whatsmeow-node/darwin-arm64",
-  "version": "0.2.3",
+  "version": "0.4.0",
   "description": "whatsmeow-node binary for macOS ARM64 (Apple Silicon)",
   "license": "MIT",
   "repository": {

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whatsmeow-node/darwin-x64",
-  "version": "0.2.3",
+  "version": "0.4.0",
   "description": "whatsmeow-node binary for macOS x64 (Intel)",
   "license": "MIT",
   "repository": {

--- a/npm/linux-arm64/package.json
+++ b/npm/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whatsmeow-node/linux-arm64",
-  "version": "0.2.3",
+  "version": "0.4.0",
   "description": "whatsmeow-node binary for Linux ARM64",
   "license": "MIT",
   "repository": {

--- a/npm/linux-x64-musl/package.json
+++ b/npm/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whatsmeow-node/linux-x64-musl",
-  "version": "0.2.3",
+  "version": "0.4.0",
   "description": "whatsmeow-node binary for Linux x64 (musl/Alpine)",
   "license": "MIT",
   "repository": {

--- a/npm/linux-x64/package.json
+++ b/npm/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whatsmeow-node/linux-x64",
-  "version": "0.2.3",
+  "version": "0.4.0",
   "description": "whatsmeow-node binary for Linux x64 (glibc)",
   "license": "MIT",
   "repository": {

--- a/npm/win32-arm64/package.json
+++ b/npm/win32-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whatsmeow-node/win32-arm64",
-  "version": "0.2.3",
+  "version": "0.4.0",
   "description": "whatsmeow-node binary for Windows ARM64",
   "license": "MIT",
   "repository": {

--- a/npm/win32-x64/package.json
+++ b/npm/win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whatsmeow-node/win32-x64",
-  "version": "0.2.3",
+  "version": "0.4.0",
   "description": "whatsmeow-node binary for Windows x64",
   "license": "MIT",
   "repository": {

--- a/ts/examples/pair.ts
+++ b/ts/examples/pair.ts
@@ -1,4 +1,4 @@
-import { createClient } from "../dist/index.js";
+import { createClient } from "../src/index.js";
 import qrcode from "qrcode-terminal";
 import path from "node:path";
 
@@ -6,7 +6,7 @@ const binaryPath = path.resolve(import.meta.dirname, "../../whatsmeow-node");
 const storePath = path.resolve(import.meta.dirname, "../session.db");
 
 const client = createClient({
-  store: storePath,
+  store: `file:${storePath}`,
   binaryPath,
 });
 

--- a/ts/examples/send-test.ts
+++ b/ts/examples/send-test.ts
@@ -1,4 +1,11 @@
-import { createClient } from "../dist/index.js";
+/**
+ * Send a test message. Requires an already-paired session.db.
+ *
+ * Usage:
+ *   npx tsx examples/send-test.ts <phone>
+ *   e.g. npx tsx examples/send-test.ts 59897756343
+ */
+import { createClient } from "../src/index.js";
 import path from "node:path";
 
 const binaryPath = path.resolve(import.meta.dirname, "../../whatsmeow-node");
@@ -6,8 +13,8 @@ const storePath = path.resolve(import.meta.dirname, "../session.db");
 
 const phone = process.argv[2];
 if (!phone) {
-  console.error("Usage: node --experimental-strip-types examples/send-test.ts <phone>");
-  console.error("  e.g. node --experimental-strip-types examples/send-test.ts 59897756343");
+  console.error("Usage: npx tsx examples/send-test.ts <phone>");
+  console.error("  e.g. npx tsx examples/send-test.ts 59897756343");
   process.exit(1);
 }
 
@@ -22,50 +29,45 @@ client.on("log", (log) => {
   if (log.level === "info") console.log(`[go] ${log.msg}`);
 });
 
-client.on("connected", ({ jid }) => {
-  console.log(`Connected as ${jid}`);
-});
-
 client.on("error", (err) => {
   console.error("Error:", err);
 });
 
 async function main() {
-  console.log("Connecting...");
-  const result = await client.connect();
-  if (!result.jid) {
-    console.error("Not paired! Run the pair script first.");
+  const initResult = await client.init();
+  if (!initResult.jid) {
+    console.error("Not paired! Run: npx tsx examples/pair.ts");
     process.exit(1);
   }
-  console.log(`Connected as ${result.jid}`);
+  console.log(`Paired as ${initResult.jid}`);
 
-  // Wait for WhatsApp connection to be fully established
-  console.log("Waiting for connection...");
-  await new Promise<void>((resolve) => {
-    const status = async () => {
-      const s = await client.status();
-      if (s.loggedIn) {
-        resolve();
-      } else {
-        setTimeout(status, 500);
-      }
-    };
-    status();
+  // Wait for the connected event before sending
+  const connected = new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error("Connection timeout (15s)")), 15_000);
+    client.once("connected", ({ jid }) => {
+      clearTimeout(timeout);
+      console.log(`Connected as ${jid}`);
+      resolve();
+    });
   });
+
+  await client.connect();
+  await connected;
 
   console.log(`Sending message to ${jid}...`);
   const resp = await client.sendMessage(jid, {
-    conversation: "Hello from whatsmeow-node! 🏎️",
+    conversation: "Hello from whatsmeow-node!",
   });
   console.log("Sent!", resp);
 
   console.log("Sending a second message...");
   const resp2 = await client.sendMessage(jid, {
-    conversation: "This is a test of the TypeScript → Go → WhatsApp pipeline.",
+    conversation: "This is a test of the TypeScript > Go > WhatsApp pipeline.",
   });
   console.log("Sent!", resp2);
 
   await client.disconnect();
+  client.close();
   console.log("Done.");
 }
 

--- a/ts/examples/smoke-test.ts
+++ b/ts/examples/smoke-test.ts
@@ -7,7 +7,7 @@
  * If a phone number is provided, messaging tests will target that JID.
  * Otherwise only read-only/self methods are tested.
  */
-import { createClient } from "../dist/index.js";
+import { createClient } from "../src/index.js";
 import path from "node:path";
 
 const binaryPath = path.resolve(import.meta.dirname, "../../whatsmeow-node");
@@ -160,7 +160,7 @@ async function main() {
       const resp = await client.sendMessage(targetJid, {
         conversation: "Smoke test from whatsmeow-node 🏎️",
       });
-      assert(resp.id, "should return message id");
+      assert(!!resp.id, "should return message id");
       sentMsgId = resp.id;
       console.log(`    sent: ${resp.id}`);
     });
@@ -168,7 +168,7 @@ async function main() {
     if (sentMsgId) {
       await test("sendReaction", async () => {
         const resp = await client.sendReaction(targetJid, initResult.jid!, sentMsgId!, "🔥");
-        assert(resp.id, "should return reaction id");
+        assert(!!resp.id, "should return reaction id");
         console.log(`    reacted: ${resp.id}`);
       });
 
@@ -176,19 +176,19 @@ async function main() {
         const resp = await client.editMessage(targetJid, sentMsgId!, {
           conversation: "Smoke test from whatsmeow-node 🏎️ (edited!)",
         });
-        assert(resp.id, "should return edit id");
+        assert(!!resp.id, "should return edit id");
         console.log(`    edited: ${resp.id}`);
       });
 
       await test("sendReaction (remove)", async () => {
         const resp = await client.sendReaction(targetJid, initResult.jid!, sentMsgId!, "");
-        assert(resp.id, "should return id");
+        assert(!!resp.id, "should return id");
       });
     }
 
     await test("sendPollCreation", async () => {
       const resp = await client.sendPollCreation(targetJid, "Smoke test poll", ["Yes", "No", "Maybe"], 1);
-      assert(resp.id, "should return poll id");
+      assert(!!resp.id, "should return poll id");
       console.log(`    poll: ${resp.id}`);
     });
 

--- a/ts/examples/types.d.ts
+++ b/ts/examples/types.d.ts
@@ -1,0 +1,6 @@
+declare module "qrcode-terminal" {
+  const qrcode: {
+    generate(text: string, options?: { small?: boolean }): void;
+  };
+  export default qrcode;
+}

--- a/ts/package.json
+++ b/ts/package.json
@@ -27,6 +27,7 @@
     "test:e2e": "vitest run --config vitest.config.e2e.ts",
     "test:watch": "vitest --exclude 'src/__tests__/e2e.test.ts'",
     "format": "prettier --write 'src/**/*.ts'",
+    "check:examples": "tsc --noEmit -p tsconfig.examples.json",
     "format:check": "prettier --check 'src/**/*.ts'"
   },
   "license": "MIT",
@@ -56,13 +57,13 @@
     "access": "public"
   },
   "optionalDependencies": {
-    "@whatsmeow-node/darwin-arm64": "0.2.3",
-    "@whatsmeow-node/darwin-x64": "0.2.3",
-    "@whatsmeow-node/linux-arm64": "0.2.3",
-    "@whatsmeow-node/linux-x64": "0.2.3",
-    "@whatsmeow-node/linux-x64-musl": "0.2.3",
-    "@whatsmeow-node/win32-arm64": "0.2.3",
-    "@whatsmeow-node/win32-x64": "0.2.3"
+    "@whatsmeow-node/darwin-arm64": "0.4.0",
+    "@whatsmeow-node/darwin-x64": "0.4.0",
+    "@whatsmeow-node/linux-arm64": "0.4.0",
+    "@whatsmeow-node/linux-x64": "0.4.0",
+    "@whatsmeow-node/linux-x64-musl": "0.4.0",
+    "@whatsmeow-node/win32-arm64": "0.4.0",
+    "@whatsmeow-node/win32-x64": "0.4.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/ts/src/errors.ts
+++ b/ts/src/errors.ts
@@ -15,13 +15,6 @@ export class TimeoutError extends WhatsmeowError {
   }
 }
 
-export class NotConnectedError extends WhatsmeowError {
-  constructor() {
-    super("Not connected", "ERR_NOT_CONNECTED");
-    this.name = "NotConnectedError";
-  }
-}
-
 export class ProcessExitedError extends WhatsmeowError {
   constructor(exitCode: number | null) {
     super(`Go process exited with code ${exitCode}`, "ERR_PROCESS_EXITED");

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -1,5 +1,5 @@
 export { WhatsmeowClient } from "./client.js";
-export { WhatsmeowError, TimeoutError, NotConnectedError, ProcessExitedError } from "./errors.js";
+export { WhatsmeowError, TimeoutError, ProcessExitedError } from "./errors.js";
 export type {
   JID,
   MessageInfo,
@@ -30,6 +30,7 @@ export type {
   Blocklist,
   MediaType,
   UploadResponse,
+  GroupInfoEvent,
   GroupRequestParticipant,
   SubGroupInfo,
   GroupMemberAddMode,

--- a/ts/src/types.ts
+++ b/ts/src/types.ts
@@ -228,6 +228,20 @@ export interface InitResult {
   jid?: JID;
 }
 
+// ── Group Info Event ────────────────────────────────
+export interface GroupInfoEvent {
+  jid: JID;
+  name?: string;
+  description?: string;
+  announce?: boolean;
+  locked?: boolean;
+  ephemeral?: boolean;
+  join?: JID[];
+  leave?: JID[];
+  promote?: JID[];
+  demote?: JID[];
+}
+
 // ── Events ─────────────────────────────────────────
 export interface WhatsmeowEvents {
   connected: { jid: JID };
@@ -253,7 +267,7 @@ export interface WhatsmeowEvents {
     media: ChatPresenceMedia;
   };
   presence: { jid: JID; presence: Presence; lastSeen?: number };
-  "group:info": Record<string, unknown>;
+  "group:info": GroupInfoEvent;
   "group:joined": { jid: JID; name: string };
   picture: { jid: JID; remove: boolean; pictureId?: string };
   "call:offer": { from: JID; callId: string };

--- a/ts/tsconfig.examples.json
+++ b/ts/tsconfig.examples.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "noEmit": true
+  },
+  "include": ["src", "examples"]
+}


### PR DESCRIPTION
## Summary

- **Fix broken `send-test.ts`** — was calling `client.connect()` expecting `{ jid }` return and `client.status()` which doesn't exist. Rewritten to use `init()` → `connect()` → `connected` event
- **Type-check examples in CI** — new `tsconfig.examples.json` + `check:examples` script, examples import from `../src/` so tsc resolves types without building first. CI runs this before build
- **README docs** — added Connection Lifecycle, Error Handling (with verified error codes from Go source), and Sending Messages sections
- **Type `group:info` event** — was `Record<string, unknown>`, now `GroupInfoEvent` with all fields matching `events.go`
- **Remove dead `NotConnectedError`** — was exported but never instantiated; no failure path produces it (`ProcessExitedError` covers "process dead", Go returns `ERR_NOT_INIT` for "not initialized")
- **Fix error code docs** — README listed `ERR_SEND_FAILED`, `ERR_UPLOAD_FAILED`, `ERR_NOT_LOGGED_IN` which don't exist; replaced with actual codes (`ERR_SEND`, `ERR_UPLOAD`, `ERR_NOT_INIT`)
- **Sync package versions** — `optionalDependencies` and `npm/*/package.json` were at `0.2.3`, synced to `0.4.0`
- **Release workflow version sync** — new step commits synced versions back to `main` after publishing; skips if released version is older than main (safe for patch releases on prior versions)

## Test plan

- [x] `npm run check:examples` — passes
- [x] `npm run build` — passes
- [x] `npm test` — 91 tests passing
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] `go run ./scripts/check-client-parity` — passes
- [ ] CI should go green (new `check:examples` step included)

🤖 Generated with [Claude Code](https://claude.com/claude-code)