### PR TITLE
Docs: translate 17 guides to PT-BR and ES

### DIFF
--- a/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/automate-group-messages.md
+++ b/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/automate-group-messages.md
@@ -1,0 +1,355 @@
+---
+title: "Cómo Automatizar Mensajes de Grupo en WhatsApp"
+sidebar_label: Automatizar Mensajes de Grupo
+sidebar_position: 12
+description: "Automatiza mensajes de grupo en WhatsApp con Node.js — envía a grupos, menciona miembros, crea grupos, administra participantes y envía difusión a múltiples grupos."
+keywords: [automatizar mensajes grupo whatsapp, bot grupo whatsapp nodejs, enviar mensaje grupo whatsapp api, mensaje masivo grupo whatsapp, automatización grupo whatsapp typescript]
+---
+
+import Head from '@docusaurus/Head';
+import {RelatedGuides} from '@site/src/components/RelatedGuides';
+
+<Head>
+  <meta property="og:image" content="https://nicastelo.github.io/whatsmeow-node/img/guides/es/automate-group-messages.png" />
+  <meta name="twitter:image" content="https://nicastelo.github.io/whatsmeow-node/img/guides/es/automate-group-messages.png" />
+  <script type="application/ld+json">
+    {JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "HowTo",
+      "name": "How to Automate Group Messages in WhatsApp",
+      "description": "Automate WhatsApp group messaging with Node.js — send to groups, mention members, create groups, manage participants, and broadcast to multiple groups.",
+      "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/automate-group-messages.png",
+      "step": [
+        {"@type": "HowToStep", "name": "List Your Groups", "text": "Use getJoinedGroups() to discover all groups you're a member of, with participant lists and settings."},
+        {"@type": "HowToStep", "name": "Send Messages to Groups", "text": "Use sendMessage() with a group JID (ending in @g.us) to send text messages to any group."},
+        {"@type": "HowToStep", "name": "Mention Group Members", "text": "Include mentionedJid in contextInfo with extendedTextMessage to @mention specific members or everyone."},
+        {"@type": "HowToStep", "name": "Listen for Group Events", "text": "Handle group:info events to react to joins, leaves, promotions, and setting changes."},
+        {"@type": "HowToStep", "name": "Broadcast to Multiple Groups", "text": "Iterate over groups with a delay between sends to avoid rate limiting."}
+      ]
+    })}
+  </script>
+  <script type="application/ld+json">
+    {JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "Article",
+      "headline": "How to Automate Group Messages in WhatsApp",
+      "description": "Automate WhatsApp group messaging with Node.js — send to groups, mention members, create groups, manage participants, and broadcast to multiple groups.",
+      "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/automate-group-messages.png",
+      "author": {"@type": "Organization", "name": "whatsmeow-node", "url": "https://nicastelo.github.io/whatsmeow-node/"},
+      "publisher": {"@type": "Organization", "name": "whatsmeow-node", "logo": {"@type": "ImageObject", "url": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/automate-group-messages.png"}}
+    })}
+  </script>
+</Head>
+
+![Cómo Automatizar Mensajes de Grupo en WhatsApp](/img/guides/es/automate-group-messages.png)
+![Cómo Automatizar Mensajes de Grupo en WhatsApp](/img/guides/es/automate-group-messages-light.png)
+
+# Cómo Automatizar Mensajes de Grupo en WhatsApp
+
+whatsmeow-node te da control total sobre los grupos de WhatsApp — envía mensajes, menciona miembros, crea grupos, administra participantes y envía difusión a múltiples grupos. Esta guía cubre las tareas de automatización de grupos más comunes.
+
+## Requisitos Previos
+
+- Una sesión vinculada de whatsmeow-node ([Cómo Vincular](pair-whatsapp))
+- Membresía en los grupos a los que quieres enviar mensajes (no puedes enviar a grupos a los que no te has unido)
+
+## Listar tus Grupos
+
+Empieza descubriendo en qué grupos estás:
+
+```typescript
+const groups = await client.getJoinedGroups();
+
+for (const g of groups) {
+  console.log(`${g.name} (${g.jid}) — ${g.participants.length} members`);
+}
+```
+
+Cada grupo tiene un JID que termina en `@g.us` — esto es lo que pasas a `sendMessage()`.
+
+## Enviar un Mensaje a un Grupo
+
+Enviar a un grupo funciona igual que enviar a un individuo — solo usa el JID del grupo:
+
+```typescript
+const groupJid = "120363XXXXX@g.us";
+await client.sendMessage(groupJid, { conversation: "Hello group!" });
+```
+
+## Mencionar Miembros del Grupo
+
+### Mencionar miembros específicos
+
+Incluye los JID en `mentionedJid` y usa `@<número>` en el cuerpo del texto:
+
+```typescript
+const memberJid = "5512345678@s.whatsapp.net";
+
+await client.sendRawMessage(groupJid, {
+  extendedTextMessage: {
+    text: `Hey @${memberJid.split("@")[0]}, check this out!`,
+    contextInfo: {
+      mentionedJid: [memberJid],
+    },
+  },
+});
+```
+
+### Mencionar a todos
+
+Obtén los participantes del grupo y construye una lista de menciones:
+
+```typescript
+const group = await client.getGroupInfo(groupJid);
+const jids = group.participants.map((p) => p.jid);
+const mentions = jids.map((j) => `@${j.split("@")[0]}`).join(" ");
+
+await client.sendRawMessage(groupJid, {
+  extendedTextMessage: {
+    text: `Attention everyone: ${mentions}`,
+    contextInfo: { mentionedJid: jids },
+  },
+});
+```
+
+## Escuchar Eventos de Grupo
+
+Reacciona a cambios en tus grupos:
+
+```typescript
+// Member changes and setting updates
+client.on("group:info", (event) => {
+  if (event.join) {
+    console.log(`New members in ${event.jid}: ${event.join.join(", ")}`);
+    // Welcome new members
+    for (const newMember of event.join) {
+      client.sendRawMessage(event.jid, {
+        extendedTextMessage: {
+          text: `Welcome @${newMember.split("@")[0]}!`,
+          contextInfo: { mentionedJid: [newMember] },
+        },
+      });
+    }
+  }
+
+  if (event.leave) {
+    console.log(`Left ${event.jid}: ${event.leave.join(", ")}`);
+  }
+
+  if (event.name) {
+    console.log(`Group renamed to: ${event.name}`);
+  }
+});
+
+// When you're added to a new group
+client.on("group:joined", ({ jid, name }) => {
+  console.log(`Joined group: ${name} (${jid})`);
+});
+```
+
+## Responder a Mensajes de Grupo
+
+Maneja los mensajes de forma diferente según si son de un grupo:
+
+```typescript
+client.on("message", async ({ info, message }) => {
+  if (info.isFromMe) return;
+  if (!info.isGroup) return; // Only handle group messages
+
+  const text =
+    (message.conversation as string) ??
+    (message.extendedTextMessage as { text?: string } | undefined)?.text;
+  if (!text) return;
+
+  // In groups, info.chat is the group JID, info.sender is the person
+  console.log(`[${info.chat}] ${info.pushName}: ${text}`);
+
+  if (text === "!members") {
+    const group = await client.getGroupInfo(info.chat);
+    const list = group.participants
+      .map((p) => `- ${p.jid}${p.isAdmin ? " (admin)" : ""}`)
+      .join("\n");
+    await client.sendMessage(info.chat, {
+      conversation: `Members:\n${list}`,
+    });
+  }
+});
+```
+
+## Difusión a Múltiples Grupos
+
+Envía el mismo mensaje a varios grupos con un delay para evitar límites de tasa:
+
+```typescript
+const groups = await client.getJoinedGroups();
+const targetGroups = groups.filter((g) => g.name.startsWith("Team "));
+
+for (const group of targetGroups) {
+  await client.sendMessage(group.jid, {
+    conversation: "Weekly reminder: standup at 9 AM tomorrow",
+  });
+
+  // Wait between sends to avoid rate limiting
+  await new Promise((r) => setTimeout(r, 2000));
+}
+
+console.log(`Sent to ${targetGroups.length} groups`);
+```
+
+:::warning Límites de tasa
+WhatsApp limita la tasa de envío, especialmente en masa. Espacia los mensajes de 1 a 3 segundos. Enviar demasiado rápido puede hacer que tu cuenta sea restringida temporalmente. Consulta [Límites de Tasa](/docs/rate-limiting).
+:::
+
+## Crear y Configurar Grupos
+
+### Crear un grupo
+
+```typescript
+const newGroup = await client.createGroup("Project Alpha", [
+  "5512345678@s.whatsapp.net",
+  "5598765432@s.whatsapp.net",
+]);
+
+console.log(`Created group: ${newGroup.name} (${newGroup.jid})`);
+```
+
+### Configurar ajustes
+
+```typescript
+await client.setGroupDescription(groupJid, "Discussion for Project Alpha");
+await client.setGroupAnnounce(groupJid, true);  // Only admins can send
+await client.setGroupLocked(groupJid, true);     // Only admins can edit info
+```
+
+### Administrar participantes
+
+```typescript
+// Add members
+await client.updateGroupParticipants(groupJid, [newMemberJid], "add");
+
+// Promote to admin
+await client.updateGroupParticipants(groupJid, [memberJid], "promote");
+
+// Remove a member
+await client.updateGroupParticipants(groupJid, [memberJid], "remove");
+```
+
+### Compartir un enlace de invitación
+
+```typescript
+const link = await client.getGroupInviteLink(groupJid);
+console.log(`Invite link: ${link}`);
+
+// Reset the link (invalidates the old one)
+const newLink = await client.getGroupInviteLink(groupJid, true);
+```
+
+## Ejemplo Completo
+
+Un bot de administración de grupo que maneja comandos y da la bienvenida a nuevos miembros:
+
+```typescript
+import { createClient } from "@whatsmeow-node/whatsmeow-node";
+
+const client = createClient({ store: "session.db" });
+
+client.on("error", (err) => console.error("Error:", err));
+
+// Welcome new members
+client.on("group:info", async (event) => {
+  if (!event.join) return;
+
+  for (const jid of event.join) {
+    await client.sendRawMessage(event.jid, {
+      extendedTextMessage: {
+        text: `Welcome @${jid.split("@")[0]}! Type !help for available commands.`,
+        contextInfo: { mentionedJid: [jid] },
+      },
+    });
+  }
+});
+
+// Handle group commands
+client.on("message", async ({ info, message }) => {
+  if (info.isFromMe || !info.isGroup) return;
+
+  const text =
+    (message.conversation as string) ??
+    (message.extendedTextMessage as { text?: string } | undefined)?.text;
+  if (!text?.startsWith("!")) return;
+
+  await client.markRead([info.id], info.chat, info.sender);
+  const command = text.toLowerCase().trim();
+
+  if (command === "!help") {
+    await client.sendMessage(info.chat, {
+      conversation: "Commands:\n!help — show this message\n!members — list members\n!invite — get invite link",
+    });
+  }
+
+  if (command === "!members") {
+    const group = await client.getGroupInfo(info.chat);
+    const list = group.participants
+      .map((p) => {
+        const role = p.isSuperAdmin ? "owner" : p.isAdmin ? "admin" : "member";
+        return `- @${p.jid.split("@")[0]} (${role})`;
+      })
+      .join("\n");
+
+    await client.sendRawMessage(info.chat, {
+      extendedTextMessage: {
+        text: `Members (${group.participants.length}):\n${list}`,
+        contextInfo: {
+          mentionedJid: group.participants.map((p) => p.jid),
+        },
+      },
+    });
+  }
+
+  if (command === "!invite") {
+    const link = await client.getGroupInviteLink(info.chat);
+    await client.sendMessage(info.chat, { conversation: link });
+  }
+});
+
+async function main() {
+  const { jid } = await client.init();
+  if (!jid) {
+    console.error("Not paired! See: How to Pair WhatsApp");
+    process.exit(1);
+  }
+
+  await client.connect();
+  await client.sendPresence("available");
+  console.log("Group bot is online!");
+
+  process.on("SIGINT", async () => {
+    await client.sendPresence("unavailable");
+    await client.disconnect();
+    client.close();
+    process.exit(0);
+  });
+}
+
+main().catch(console.error);
+```
+
+## Errores Comunes
+
+:::warning Envía a `info.chat`, no a `info.sender`
+En grupos, `info.chat` es el JID del grupo e `info.sender` es el individuo. Siempre responde a `info.chat` — enviar a `info.sender` inicia una conversación privada.
+:::
+
+:::warning Grupos de solo anuncios
+Si un grupo tiene `announce: true`, solo los administradores pueden enviar mensajes. Tu bot debe ser admin para enviar mensajes en esos grupos.
+:::
+
+:::warning Límites de tasa en difusiones
+Enviar el mismo mensaje a muchos grupos demasiado rápido activará el limitador de tasa de WhatsApp. Siempre agrega un delay (1-3 segundos) entre envíos. Consulta [Límites de Tasa](/docs/rate-limiting).
+:::
+
+:::warning Operaciones de admin de grupo
+`updateGroupParticipants` con `"promote"`, `"demote"` o `"remove"` requiere que tu bot sea administrador del grupo. `"add"` también puede requerir permisos de admin dependiendo de la configuración del grupo.
+:::
+
+<RelatedGuides slugs={["build-a-bot", "send-messages-typescript", "send-notifications", "poll-bot"]} />

--- a/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/automate-group-messages.md
+++ b/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/automate-group-messages.md
@@ -16,15 +16,15 @@ import {RelatedGuides} from '@site/src/components/RelatedGuides';
     {JSON.stringify({
       "@context": "https://schema.org",
       "@type": "HowTo",
-      "name": "How to Automate Group Messages in WhatsApp",
-      "description": "Automate WhatsApp group messaging with Node.js — send to groups, mention members, create groups, manage participants, and broadcast to multiple groups.",
+      "name": "Cómo Automatizar Mensajes de Grupo en WhatsApp",
+      "description": "Automatiza mensajes de grupo en WhatsApp con Node.js — envía a grupos, menciona miembros, crea grupos, administra participantes y envía difusión a múltiples grupos.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/automate-group-messages.png",
       "step": [
-        {"@type": "HowToStep", "name": "List Your Groups", "text": "Use getJoinedGroups() to discover all groups you're a member of, with participant lists and settings."},
-        {"@type": "HowToStep", "name": "Send Messages to Groups", "text": "Use sendMessage() with a group JID (ending in @g.us) to send text messages to any group."},
-        {"@type": "HowToStep", "name": "Mention Group Members", "text": "Include mentionedJid in contextInfo with extendedTextMessage to @mention specific members or everyone."},
-        {"@type": "HowToStep", "name": "Listen for Group Events", "text": "Handle group:info events to react to joins, leaves, promotions, and setting changes."},
-        {"@type": "HowToStep", "name": "Broadcast to Multiple Groups", "text": "Iterate over groups with a delay between sends to avoid rate limiting."}
+        {"@type": "HowToStep", "name": "Listar tus grupos", "text": "Usa getJoinedGroups() para descubrir todos los grupos de los que eres miembro, con listas de participantes y configuraciones."},
+        {"@type": "HowToStep", "name": "Enviar mensajes a grupos", "text": "Usa sendMessage() con un JID de grupo (que termina en @g.us) para enviar mensajes de texto a cualquier grupo."},
+        {"@type": "HowToStep", "name": "Mencionar miembros del grupo", "text": "Incluye mentionedJid en contextInfo con extendedTextMessage para @mencionar miembros específicos o a todos."},
+        {"@type": "HowToStep", "name": "Escuchar eventos de grupo", "text": "Maneja los eventos group:info para reaccionar a uniones, salidas, promociones y cambios de configuración."},
+        {"@type": "HowToStep", "name": "Difusión a múltiples grupos", "text": "Itera sobre los grupos con un delay entre envíos para evitar límites de tasa."}
       ]
     })}
   </script>
@@ -32,8 +32,8 @@ import {RelatedGuides} from '@site/src/components/RelatedGuides';
     {JSON.stringify({
       "@context": "https://schema.org",
       "@type": "Article",
-      "headline": "How to Automate Group Messages in WhatsApp",
-      "description": "Automate WhatsApp group messaging with Node.js — send to groups, mention members, create groups, manage participants, and broadcast to multiple groups.",
+      "headline": "Cómo Automatizar Mensajes de Grupo en WhatsApp",
+      "description": "Automatiza mensajes de grupo en WhatsApp con Node.js — envía a grupos, menciona miembros, crea grupos, administra participantes y envía difusión a múltiples grupos.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/automate-group-messages.png",
       "author": {"@type": "Organization", "name": "whatsmeow-node", "url": "https://nicastelo.github.io/whatsmeow-node/"},
       "publisher": {"@type": "Organization", "name": "whatsmeow-node", "logo": {"@type": "ImageObject", "url": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/automate-group-messages.png"}}

--- a/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/build-a-bot.md
+++ b/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/build-a-bot.md
@@ -19,12 +19,12 @@ import Head from '@docusaurus/Head';
       "description": "Crea un bot de WhatsApp con Node.js y TypeScript — recibe mensajes, maneja comandos, responde con citas y gestiona conexiones.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/build-a-bot.png",
       "step": [
-        {"@type": "HowToStep", "name": "Create the Client", "text": "Initialize a WhatsmeowClient with createClient() and a session store."},
-        {"@type": "HowToStep", "name": "Handle Incoming Messages", "text": "Listen for the message event and extract text from conversation or extendedTextMessage."},
-        {"@type": "HowToStep", "name": "Reply to Messages", "text": "Use sendMessage for text or sendRawMessage with contextInfo for quoted replies."},
-        {"@type": "HowToStep", "name": "Add Commands", "text": "Route messages starting with ! to command handlers like !ping and !help."},
-        {"@type": "HowToStep", "name": "Handle Errors and Reconnection", "text": "Listen for logged_out and disconnected events. Auto-reconnect is built-in."},
-        {"@type": "HowToStep", "name": "Graceful Shutdown", "text": "Handle SIGINT to set presence unavailable and disconnect cleanly."}
+        {"@type": "HowToStep", "name": "Crear el cliente", "text": "Inicializa un WhatsmeowClient con createClient() y un almacén de sesión."},
+        {"@type": "HowToStep", "name": "Manejar mensajes entrantes", "text": "Escucha el evento message y extrae el texto de conversation o extendedTextMessage."},
+        {"@type": "HowToStep", "name": "Responder mensajes", "text": "Usa sendMessage para texto o sendRawMessage con contextInfo para respuestas citadas."},
+        {"@type": "HowToStep", "name": "Agregar comandos", "text": "Enruta los mensajes que comienzan con ! a manejadores de comandos como !ping y !help."},
+        {"@type": "HowToStep", "name": "Manejar errores y reconexión", "text": "Escucha los eventos logged_out y disconnected. La reconexión automática está incluida."},
+        {"@type": "HowToStep", "name": "Cierre elegante", "text": "Maneja SIGINT para establecer la presencia como no disponible y desconectar limpiamente."}
       ]
     })}
   </script>

--- a/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/connect-to-ai.md
+++ b/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/connect-to-ai.md
@@ -19,10 +19,10 @@ import Head from '@docusaurus/Head';
       "description": "Construye un chatbot de WhatsApp con IA conectando whatsmeow-node con Claude a través del SDK de Anthropic. Incluye historial de conversación e indicadores de escritura.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/connect-to-ai.png",
       "step": [
-        {"@type": "HowToStep", "name": "Set Up Both Clients", "text": "Initialize WhatsmeowClient with createClient() and Anthropic client with new Anthropic()."},
-        {"@type": "HowToStep", "name": "Handle Incoming Messages", "text": "Listen for the message event, skip own messages, show typing, and extract text."},
-        {"@type": "HowToStep", "name": "Send to Claude", "text": "Call anthropic.messages.create() with the user message and send the response back via sendMessage."},
-        {"@type": "HowToStep", "name": "Add Conversation History", "text": "Store message history per user JID in a Map and pass it to Claude for multi-turn conversations."}
+        {"@type": "HowToStep", "name": "Configurar ambos clientes", "text": "Inicializa WhatsmeowClient con createClient() y el cliente de Anthropic con new Anthropic()."},
+        {"@type": "HowToStep", "name": "Manejar mensajes entrantes", "text": "Escucha el evento message, omite los mensajes propios, muestra el indicador de escritura y extrae el texto."},
+        {"@type": "HowToStep", "name": "Enviar a Claude", "text": "Llama a anthropic.messages.create() con el mensaje del usuario y envía la respuesta de vuelta con sendMessage."},
+        {"@type": "HowToStep", "name": "Agregar historial de conversación", "text": "Almacena el historial de mensajes por JID de usuario en un Map y pásalo a Claude para conversaciones multi-turno."}
       ]
     })}
   </script>

--- a/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/connect-to-chatgpt.md
+++ b/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/connect-to-chatgpt.md
@@ -1,0 +1,235 @@
+---
+title: "Cómo Conectar WhatsApp con ChatGPT (OpenAI)"
+sidebar_label: Conectar con ChatGPT
+sidebar_position: 13
+description: "Crea un chatbot de WhatsApp con ChatGPT usando whatsmeow-node y el SDK de OpenAI. Incluye historial de conversación, indicadores de escritura y GPT-4.1."
+keywords: [conectar whatsapp chatgpt, bot whatsapp chatgpt, bot whatsapp openai nodejs, bot whatsapp gpt typescript, integración chatgpt whatsapp]
+---
+
+import Head from '@docusaurus/Head';
+import {RelatedGuides} from '@site/src/components/RelatedGuides';
+
+<Head>
+  <meta property="og:image" content="https://nicastelo.github.io/whatsmeow-node/img/guides/es/connect-to-chatgpt.png" />
+  <meta name="twitter:image" content="https://nicastelo.github.io/whatsmeow-node/img/guides/es/connect-to-chatgpt.png" />
+  <script type="application/ld+json">
+    {JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "HowTo",
+      "name": "How to Connect WhatsApp to ChatGPT (OpenAI)",
+      "description": "Build a WhatsApp chatbot powered by ChatGPT using whatsmeow-node and the OpenAI SDK. Includes conversation history, typing indicators, and GPT-4.1.",
+      "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/connect-to-chatgpt.png",
+      "step": [
+        {"@type": "HowToStep", "name": "Set Up Both Clients", "text": "Initialize WhatsmeowClient with createClient() and OpenAI client with new OpenAI()."},
+        {"@type": "HowToStep", "name": "Handle Incoming Messages", "text": "Listen for the message event, skip own messages, show typing, and extract text."},
+        {"@type": "HowToStep", "name": "Send to ChatGPT", "text": "Call openai.chat.completions.create() with the user message and send the response back via sendMessage."},
+        {"@type": "HowToStep", "name": "Add Conversation History", "text": "Store message history per user JID in a Map and pass it to ChatGPT for multi-turn conversations."}
+      ]
+    })}
+  </script>
+  <script type="application/ld+json">
+    {JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "Article",
+      "headline": "How to Connect WhatsApp to ChatGPT (OpenAI)",
+      "description": "Build a WhatsApp chatbot powered by ChatGPT using whatsmeow-node and the OpenAI SDK. Includes conversation history, typing indicators, and GPT-4.1.",
+      "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/connect-to-chatgpt.png",
+      "author": {"@type": "Organization", "name": "whatsmeow-node", "url": "https://nicastelo.github.io/whatsmeow-node/"},
+      "publisher": {"@type": "Organization", "name": "whatsmeow-node", "logo": {"@type": "ImageObject", "url": "https://nicastelo.github.io/whatsmeow-node/img/image.png"}}
+    })}
+  </script>
+</Head>
+
+![Cómo Conectar WhatsApp con ChatGPT (OpenAI)](/img/guides/es/connect-to-chatgpt.png)
+![Cómo Conectar WhatsApp con ChatGPT (OpenAI)](/img/guides/es/connect-to-chatgpt-light.png)
+
+# Cómo Conectar WhatsApp con ChatGPT (OpenAI)
+
+Combina whatsmeow-node con el SDK de OpenAI para crear un chatbot de WhatsApp potenciado por GPT-4.1. Los mensajes entran por WhatsApp, se envían a OpenAI para obtener una respuesta, y la respuesta vuelve al usuario — con indicadores de escritura mientras el modelo piensa.
+
+## Requisitos Previos
+
+- Una sesión vinculada de whatsmeow-node ([Cómo Vincular](pair-whatsapp))
+- Una API key de OpenAI (configurada como variable de entorno `OPENAI_API_KEY`)
+- El SDK de OpenAI: `npm install openai`
+
+## Paso 1: Configurar Ambos Clientes
+
+```typescript
+import { createClient } from "@whatsmeow-node/whatsmeow-node";
+import OpenAI from "openai";
+
+const client = createClient({ store: "session.db" });
+const openai = new OpenAI(); // reads OPENAI_API_KEY from env
+
+const SYSTEM_PROMPT = "You are a helpful WhatsApp assistant. Keep responses concise — under 500 characters when possible, since this is a chat interface.";
+```
+
+## Paso 2: Manejar Mensajes Entrantes
+
+```typescript
+client.on("message", async ({ info, message }) => {
+  if (info.isFromMe) return;
+
+  const text =
+    (message.conversation as string) ??
+    (message.extendedTextMessage as { text?: string } | undefined)?.text;
+  if (!text) return;
+
+  await client.sendChatPresence(info.chat, "composing");
+
+  const reply = await askChatGPT(info.sender, text);
+  await client.sendMessage(info.chat, { conversation: reply });
+});
+```
+
+## Paso 3: Enviar a ChatGPT
+
+```typescript
+async function askChatGPT(userJid: string, userMessage: string): Promise<string> {
+  const response = await openai.chat.completions.create({
+    model: "gpt-4.1",
+    messages: [
+      { role: "system", content: SYSTEM_PROMPT },
+      { role: "user", content: userMessage },
+    ],
+  });
+
+  return response.choices[0].message.content ?? "I couldn't generate a response.";
+}
+```
+
+## Paso 4: Agregar Historial de Conversación
+
+Para conversaciones multi-turno, almacena el historial de mensajes por usuario:
+
+```typescript
+import type { ChatCompletionMessageParam } from "openai/resources/chat/completions";
+
+const conversations = new Map<string, ChatCompletionMessageParam[]>();
+const MAX_HISTORY = 20;
+
+async function askChatGPT(userJid: string, userMessage: string): Promise<string> {
+  const history = conversations.get(userJid) ?? [];
+  history.push({ role: "user", content: userMessage });
+
+  if (history.length > MAX_HISTORY) {
+    history.splice(0, history.length - MAX_HISTORY);
+  }
+
+  const response = await openai.chat.completions.create({
+    model: "gpt-4.1",
+    messages: [{ role: "system", content: SYSTEM_PROMPT }, ...history],
+  });
+
+  const reply = response.choices[0].message.content ?? "I couldn't generate a response.";
+
+  history.push({ role: "assistant", content: reply });
+  conversations.set(userJid, history);
+
+  return reply;
+}
+```
+
+## Ejemplo Completo
+
+```typescript
+import { createClient } from "@whatsmeow-node/whatsmeow-node";
+import OpenAI from "openai";
+import type { ChatCompletionMessageParam } from "openai/resources/chat/completions";
+
+const client = createClient({ store: "session.db" });
+const openai = new OpenAI();
+
+const SYSTEM_PROMPT =
+  "You are a helpful WhatsApp assistant. Keep responses concise — under 500 characters when possible, since this is a chat interface.";
+
+const conversations = new Map<string, ChatCompletionMessageParam[]>();
+const MAX_HISTORY = 20;
+
+async function askChatGPT(userJid: string, userMessage: string): Promise<string> {
+  const history = conversations.get(userJid) ?? [];
+  history.push({ role: "user", content: userMessage });
+
+  if (history.length > MAX_HISTORY) {
+    history.splice(0, history.length - MAX_HISTORY);
+  }
+
+  const response = await openai.chat.completions.create({
+    model: "gpt-4.1",
+    messages: [{ role: "system", content: SYSTEM_PROMPT }, ...history],
+  });
+
+  const reply = response.choices[0].message.content ?? "I couldn't generate a response.";
+
+  history.push({ role: "assistant", content: reply });
+  conversations.set(userJid, history);
+
+  return reply;
+}
+
+client.on("message", async ({ info, message }) => {
+  if (info.isFromMe) return;
+
+  const text =
+    (message.conversation as string) ??
+    (message.extendedTextMessage as { text?: string } | undefined)?.text;
+  if (!text) return;
+
+  console.log(`${info.pushName}: ${text}`);
+  await client.sendChatPresence(info.chat, "composing");
+
+  try {
+    const reply = await askChatGPT(info.sender, text);
+    await client.sendMessage(info.chat, { conversation: reply });
+    console.log(`→ ${reply.slice(0, 80)}...`);
+  } catch (err) {
+    console.error("OpenAI API error:", err);
+    await client.sendMessage(info.chat, {
+      conversation: "Sorry, I'm having trouble right now. Try again in a moment.",
+    });
+  }
+});
+
+client.on("logged_out", ({ reason }) => {
+  console.error(`Logged out: ${reason}`);
+  client.close();
+  process.exit(1);
+});
+
+async function main() {
+  const { jid } = await client.init();
+  if (!jid) {
+    console.error("Not paired! See: How to Pair WhatsApp");
+    process.exit(1);
+  }
+  await client.connect();
+  await client.sendPresence("available");
+  console.log("ChatGPT bot is online!");
+
+  process.on("SIGINT", async () => {
+    await client.sendPresence("unavailable");
+    await client.disconnect();
+    client.close();
+    process.exit(0);
+  });
+}
+
+main().catch(console.error);
+```
+
+## Errores Comunes
+
+:::warning Bucles de eco
+Siempre verifica `info.isFromMe` primero. Sin esto, el bot envía un mensaje, ve su propio mensaje, lo envía a ChatGPT y responde de nuevo — para siempre.
+:::
+
+:::warning Exposición de la API key
+Nunca escribas tu API key directamente en el código. Usa variables de entorno (`OPENAI_API_KEY`) o un archivo `.env` (agregado a `.gitignore`).
+:::
+
+:::warning Límites de tasa en ambos lados
+Tanto la API de OpenAI como WhatsApp tienen límites de tasa. Para la API de OpenAI, maneja errores `429` con backoff exponencial. Para WhatsApp, evita enviar demasiados mensajes muy rápido — consulta [Límites de Tasa](/docs/rate-limiting).
+:::
+
+<RelatedGuides slugs={["connect-to-ai", "connect-to-gemini", "connect-to-ollama", "connect-to-deepseek"]} />

--- a/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/connect-to-chatgpt.md
+++ b/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/connect-to-chatgpt.md
@@ -16,14 +16,14 @@ import {RelatedGuides} from '@site/src/components/RelatedGuides';
     {JSON.stringify({
       "@context": "https://schema.org",
       "@type": "HowTo",
-      "name": "How to Connect WhatsApp to ChatGPT (OpenAI)",
-      "description": "Build a WhatsApp chatbot powered by ChatGPT using whatsmeow-node and the OpenAI SDK. Includes conversation history, typing indicators, and GPT-4.1.",
+      "name": "Cómo Conectar WhatsApp con ChatGPT (OpenAI)",
+      "description": "Crea un chatbot de WhatsApp con ChatGPT usando whatsmeow-node y el SDK de OpenAI. Incluye historial de conversación, indicadores de escritura y GPT-4.1.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/connect-to-chatgpt.png",
       "step": [
-        {"@type": "HowToStep", "name": "Set Up Both Clients", "text": "Initialize WhatsmeowClient with createClient() and OpenAI client with new OpenAI()."},
-        {"@type": "HowToStep", "name": "Handle Incoming Messages", "text": "Listen for the message event, skip own messages, show typing, and extract text."},
-        {"@type": "HowToStep", "name": "Send to ChatGPT", "text": "Call openai.chat.completions.create() with the user message and send the response back via sendMessage."},
-        {"@type": "HowToStep", "name": "Add Conversation History", "text": "Store message history per user JID in a Map and pass it to ChatGPT for multi-turn conversations."}
+        {"@type": "HowToStep", "name": "Configurar ambos clientes", "text": "Inicializa WhatsmeowClient con createClient() y el cliente de OpenAI con new OpenAI()."},
+        {"@type": "HowToStep", "name": "Manejar mensajes entrantes", "text": "Escucha el evento message, omite los mensajes propios, muestra el indicador de escritura y extrae el texto."},
+        {"@type": "HowToStep", "name": "Enviar a ChatGPT", "text": "Llama a openai.chat.completions.create() con el mensaje del usuario y envía la respuesta de vuelta con sendMessage."},
+        {"@type": "HowToStep", "name": "Agregar historial de conversación", "text": "Almacena el historial de mensajes por JID de usuario en un Map y pásalo a ChatGPT para conversaciones multi-turno."}
       ]
     })}
   </script>
@@ -31,8 +31,8 @@ import {RelatedGuides} from '@site/src/components/RelatedGuides';
     {JSON.stringify({
       "@context": "https://schema.org",
       "@type": "Article",
-      "headline": "How to Connect WhatsApp to ChatGPT (OpenAI)",
-      "description": "Build a WhatsApp chatbot powered by ChatGPT using whatsmeow-node and the OpenAI SDK. Includes conversation history, typing indicators, and GPT-4.1.",
+      "headline": "Cómo Conectar WhatsApp con ChatGPT (OpenAI)",
+      "description": "Crea un chatbot de WhatsApp con ChatGPT usando whatsmeow-node y el SDK de OpenAI. Incluye historial de conversación, indicadores de escritura y GPT-4.1.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/connect-to-chatgpt.png",
       "author": {"@type": "Organization", "name": "whatsmeow-node", "url": "https://nicastelo.github.io/whatsmeow-node/"},
       "publisher": {"@type": "Organization", "name": "whatsmeow-node", "logo": {"@type": "ImageObject", "url": "https://nicastelo.github.io/whatsmeow-node/img/image.png"}}

--- a/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/connect-to-deepseek.md
+++ b/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/connect-to-deepseek.md
@@ -1,0 +1,258 @@
+---
+title: "Cómo Conectar WhatsApp con DeepSeek"
+sidebar_label: Conectar con DeepSeek
+sidebar_position: 15
+description: "Crea un chatbot de WhatsApp con DeepSeek usando whatsmeow-node y el SDK de OpenAI. DeepSeek usa una API compatible con OpenAI."
+keywords: [conectar whatsapp deepseek, bot whatsapp deepseek, deepseek whatsapp nodejs, integración whatsapp deepseek, chatbot deepseek whatsapp]
+---
+
+import Head from '@docusaurus/Head';
+import {RelatedGuides} from '@site/src/components/RelatedGuides';
+
+<Head>
+  <meta property="og:image" content="https://nicastelo.github.io/whatsmeow-node/img/guides/es/connect-to-deepseek.png" />
+  <meta name="twitter:image" content="https://nicastelo.github.io/whatsmeow-node/img/guides/es/connect-to-deepseek.png" />
+  <script type="application/ld+json">
+    {JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "HowTo",
+      "name": "How to Connect WhatsApp to DeepSeek",
+      "description": "Build a WhatsApp chatbot powered by DeepSeek using whatsmeow-node and the OpenAI SDK. DeepSeek uses an OpenAI-compatible API.",
+      "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/connect-to-deepseek.png",
+      "step": [
+        {"@type": "HowToStep", "name": "Set Up Both Clients", "text": "Initialize WhatsmeowClient with createClient() and OpenAI client pointing to DeepSeek's base URL."},
+        {"@type": "HowToStep", "name": "Handle Incoming Messages", "text": "Listen for the message event, skip own messages, show typing, and extract text."},
+        {"@type": "HowToStep", "name": "Send to DeepSeek", "text": "Call openai.chat.completions.create() with the deepseek-chat model and send the response back via sendMessage."},
+        {"@type": "HowToStep", "name": "Add Conversation History", "text": "Store message history per user JID in a Map and pass it to DeepSeek for multi-turn conversations."}
+      ]
+    })}
+  </script>
+  <script type="application/ld+json">
+    {JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "Article",
+      "headline": "How to Connect WhatsApp to DeepSeek",
+      "description": "Build a WhatsApp chatbot powered by DeepSeek using whatsmeow-node and the OpenAI SDK. DeepSeek uses an OpenAI-compatible API.",
+      "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/connect-to-deepseek.png",
+      "author": {"@type": "Organization", "name": "whatsmeow-node", "url": "https://nicastelo.github.io/whatsmeow-node/"},
+      "publisher": {"@type": "Organization", "name": "whatsmeow-node", "logo": {"@type": "ImageObject", "url": "https://nicastelo.github.io/whatsmeow-node/img/image.png"}}
+    })}
+  </script>
+</Head>
+
+![Cómo Conectar WhatsApp con DeepSeek](/img/guides/es/connect-to-deepseek.png)
+![Cómo Conectar WhatsApp con DeepSeek](/img/guides/es/connect-to-deepseek-light.png)
+
+# Cómo Conectar WhatsApp con DeepSeek
+
+DeepSeek expone una API compatible con OpenAI, así que puedes usar el mismo paquete npm `openai` — solo apúntalo al endpoint de DeepSeek. Esto facilita cambiar entre OpenAI, DeepSeek y otros proveedores compatibles.
+
+## Requisitos Previos
+
+- Una sesión vinculada de whatsmeow-node ([Cómo Vincular](pair-whatsapp))
+- Una API key de DeepSeek (configurada como variable de entorno `DEEPSEEK_API_KEY`) — obtén una en [platform.deepseek.com](https://platform.deepseek.com/)
+- El SDK de OpenAI: `npm install openai`
+
+## Paso 1: Configurar Ambos Clientes
+
+La única diferencia con OpenAI es el `baseURL` y la API key:
+
+```typescript
+import { createClient } from "@whatsmeow-node/whatsmeow-node";
+import OpenAI from "openai";
+
+const client = createClient({ store: "session.db" });
+const openai = new OpenAI({
+  baseURL: "https://api.deepseek.com",
+  apiKey: process.env.DEEPSEEK_API_KEY,
+});
+
+const SYSTEM_PROMPT = "You are a helpful WhatsApp assistant. Keep responses concise — under 500 characters when possible, since this is a chat interface.";
+```
+
+## Paso 2: Manejar Mensajes Entrantes
+
+```typescript
+client.on("message", async ({ info, message }) => {
+  if (info.isFromMe) return;
+
+  const text =
+    (message.conversation as string) ??
+    (message.extendedTextMessage as { text?: string } | undefined)?.text;
+  if (!text) return;
+
+  await client.sendChatPresence(info.chat, "composing");
+
+  const reply = await askDeepSeek(info.sender, text);
+  await client.sendMessage(info.chat, { conversation: reply });
+});
+```
+
+## Paso 3: Enviar a DeepSeek
+
+```typescript
+async function askDeepSeek(userJid: string, userMessage: string): Promise<string> {
+  const response = await openai.chat.completions.create({
+    model: "deepseek-chat",
+    messages: [
+      { role: "system", content: SYSTEM_PROMPT },
+      { role: "user", content: userMessage },
+    ],
+  });
+
+  return response.choices[0].message.content ?? "I couldn't generate a response.";
+}
+```
+
+:::info
+DeepSeek también ofrece `deepseek-reasoner` para tareas de razonamiento complejo. Cambia el nombre del modelo para probarlo.
+:::
+
+## Paso 4: Agregar Historial de Conversación
+
+Como DeepSeek usa el formato compatible con OpenAI, el patrón de historial es idéntico:
+
+```typescript
+import type { ChatCompletionMessageParam } from "openai/resources/chat/completions";
+
+const conversations = new Map<string, ChatCompletionMessageParam[]>();
+const MAX_HISTORY = 20;
+
+async function askDeepSeek(userJid: string, userMessage: string): Promise<string> {
+  const history = conversations.get(userJid) ?? [];
+  history.push({ role: "user", content: userMessage });
+
+  if (history.length > MAX_HISTORY) {
+    history.splice(0, history.length - MAX_HISTORY);
+  }
+
+  const response = await openai.chat.completions.create({
+    model: "deepseek-chat",
+    messages: [{ role: "system", content: SYSTEM_PROMPT }, ...history],
+  });
+
+  const reply = response.choices[0].message.content ?? "I couldn't generate a response.";
+
+  history.push({ role: "assistant", content: reply });
+  conversations.set(userJid, history);
+
+  return reply;
+}
+```
+
+## Ejemplo Completo
+
+```typescript
+import { createClient } from "@whatsmeow-node/whatsmeow-node";
+import OpenAI from "openai";
+import type { ChatCompletionMessageParam } from "openai/resources/chat/completions";
+
+const client = createClient({ store: "session.db" });
+const openai = new OpenAI({
+  baseURL: "https://api.deepseek.com",
+  apiKey: process.env.DEEPSEEK_API_KEY,
+});
+
+const SYSTEM_PROMPT =
+  "You are a helpful WhatsApp assistant. Keep responses concise — under 500 characters when possible, since this is a chat interface.";
+
+const conversations = new Map<string, ChatCompletionMessageParam[]>();
+const MAX_HISTORY = 20;
+
+async function askDeepSeek(userJid: string, userMessage: string): Promise<string> {
+  const history = conversations.get(userJid) ?? [];
+  history.push({ role: "user", content: userMessage });
+
+  if (history.length > MAX_HISTORY) {
+    history.splice(0, history.length - MAX_HISTORY);
+  }
+
+  const response = await openai.chat.completions.create({
+    model: "deepseek-chat",
+    messages: [{ role: "system", content: SYSTEM_PROMPT }, ...history],
+  });
+
+  const reply = response.choices[0].message.content ?? "I couldn't generate a response.";
+
+  history.push({ role: "assistant", content: reply });
+  conversations.set(userJid, history);
+
+  return reply;
+}
+
+client.on("message", async ({ info, message }) => {
+  if (info.isFromMe) return;
+
+  const text =
+    (message.conversation as string) ??
+    (message.extendedTextMessage as { text?: string } | undefined)?.text;
+  if (!text) return;
+
+  console.log(`${info.pushName}: ${text}`);
+  await client.sendChatPresence(info.chat, "composing");
+
+  try {
+    const reply = await askDeepSeek(info.sender, text);
+    await client.sendMessage(info.chat, { conversation: reply });
+    console.log(`→ ${reply.slice(0, 80)}...`);
+  } catch (err) {
+    console.error("DeepSeek API error:", err);
+    await client.sendMessage(info.chat, {
+      conversation: "Sorry, I'm having trouble right now. Try again in a moment.",
+    });
+  }
+});
+
+client.on("logged_out", ({ reason }) => {
+  console.error(`Logged out: ${reason}`);
+  client.close();
+  process.exit(1);
+});
+
+async function main() {
+  const { jid } = await client.init();
+  if (!jid) {
+    console.error("Not paired! See: How to Pair WhatsApp");
+    process.exit(1);
+  }
+  await client.connect();
+  await client.sendPresence("available");
+  console.log("DeepSeek bot is online!");
+
+  process.on("SIGINT", async () => {
+    await client.sendPresence("unavailable");
+    await client.disconnect();
+    client.close();
+    process.exit(0);
+  });
+}
+
+main().catch(console.error);
+```
+
+## Cambiar Entre Proveedores
+
+Como DeepSeek, OpenAI y muchos otros proveedores usan el mismo formato de API, puedes hacer configurable el proveedor:
+
+```typescript
+const openai = new OpenAI({
+  baseURL: process.env.AI_BASE_URL ?? "https://api.openai.com/v1",
+  apiKey: process.env.AI_API_KEY,
+});
+
+const model = process.env.AI_MODEL ?? "gpt-4o";
+```
+
+Esto funciona con cualquier proveedor compatible con OpenAI — DeepSeek, Groq, Together AI, Mistral y más.
+
+## Errores Comunes
+
+:::warning Bucles de eco
+Siempre verifica `info.isFromMe` primero. Sin esto, el bot responde a sus propios mensajes para siempre.
+:::
+
+:::warning Exposición de la API key
+Nunca escribas tu API key directamente en el código. Usa variables de entorno o un archivo `.env` (agregado a `.gitignore`).
+:::
+
+<RelatedGuides slugs={["connect-to-chatgpt", "connect-to-ai", "connect-to-ollama"]} />

--- a/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/connect-to-deepseek.md
+++ b/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/connect-to-deepseek.md
@@ -16,14 +16,14 @@ import {RelatedGuides} from '@site/src/components/RelatedGuides';
     {JSON.stringify({
       "@context": "https://schema.org",
       "@type": "HowTo",
-      "name": "How to Connect WhatsApp to DeepSeek",
-      "description": "Build a WhatsApp chatbot powered by DeepSeek using whatsmeow-node and the OpenAI SDK. DeepSeek uses an OpenAI-compatible API.",
+      "name": "Cómo Conectar WhatsApp con DeepSeek",
+      "description": "Crea un chatbot de WhatsApp con DeepSeek usando whatsmeow-node y el SDK de OpenAI. DeepSeek usa una API compatible con OpenAI.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/connect-to-deepseek.png",
       "step": [
-        {"@type": "HowToStep", "name": "Set Up Both Clients", "text": "Initialize WhatsmeowClient with createClient() and OpenAI client pointing to DeepSeek's base URL."},
-        {"@type": "HowToStep", "name": "Handle Incoming Messages", "text": "Listen for the message event, skip own messages, show typing, and extract text."},
-        {"@type": "HowToStep", "name": "Send to DeepSeek", "text": "Call openai.chat.completions.create() with the deepseek-chat model and send the response back via sendMessage."},
-        {"@type": "HowToStep", "name": "Add Conversation History", "text": "Store message history per user JID in a Map and pass it to DeepSeek for multi-turn conversations."}
+        {"@type": "HowToStep", "name": "Configurar ambos clientes", "text": "Inicializa WhatsmeowClient con createClient() y el cliente de OpenAI apuntando a la URL base de DeepSeek."},
+        {"@type": "HowToStep", "name": "Manejar mensajes entrantes", "text": "Escucha el evento message, omite los mensajes propios, muestra el indicador de escritura y extrae el texto."},
+        {"@type": "HowToStep", "name": "Enviar a DeepSeek", "text": "Llama a openai.chat.completions.create() con el modelo deepseek-chat y envía la respuesta de vuelta con sendMessage."},
+        {"@type": "HowToStep", "name": "Agregar historial de conversación", "text": "Almacena el historial de mensajes por JID de usuario en un Map y pásalo a DeepSeek para conversaciones multi-turno."}
       ]
     })}
   </script>
@@ -31,8 +31,8 @@ import {RelatedGuides} from '@site/src/components/RelatedGuides';
     {JSON.stringify({
       "@context": "https://schema.org",
       "@type": "Article",
-      "headline": "How to Connect WhatsApp to DeepSeek",
-      "description": "Build a WhatsApp chatbot powered by DeepSeek using whatsmeow-node and the OpenAI SDK. DeepSeek uses an OpenAI-compatible API.",
+      "headline": "Cómo Conectar WhatsApp con DeepSeek",
+      "description": "Crea un chatbot de WhatsApp con DeepSeek usando whatsmeow-node y el SDK de OpenAI. DeepSeek usa una API compatible con OpenAI.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/connect-to-deepseek.png",
       "author": {"@type": "Organization", "name": "whatsmeow-node", "url": "https://nicastelo.github.io/whatsmeow-node/"},
       "publisher": {"@type": "Organization", "name": "whatsmeow-node", "logo": {"@type": "ImageObject", "url": "https://nicastelo.github.io/whatsmeow-node/img/image.png"}}

--- a/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/connect-to-gemini.md
+++ b/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/connect-to-gemini.md
@@ -16,14 +16,14 @@ import {RelatedGuides} from '@site/src/components/RelatedGuides';
     {JSON.stringify({
       "@context": "https://schema.org",
       "@type": "HowTo",
-      "name": "How to Connect WhatsApp to Google Gemini",
-      "description": "Build a WhatsApp chatbot powered by Google Gemini using whatsmeow-node and the Google GenAI SDK. Includes conversation history and typing indicators.",
+      "name": "Cómo Conectar WhatsApp con Google Gemini",
+      "description": "Crea un chatbot de WhatsApp con Google Gemini usando whatsmeow-node y el SDK de Google GenAI. Incluye historial de conversación e indicadores de escritura.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/connect-to-gemini.png",
       "step": [
-        {"@type": "HowToStep", "name": "Set Up Both Clients", "text": "Initialize WhatsmeowClient with createClient() and Google GenAI with new GoogleGenAI()."},
-        {"@type": "HowToStep", "name": "Handle Incoming Messages", "text": "Listen for the message event, skip own messages, show typing, and extract text."},
-        {"@type": "HowToStep", "name": "Send to Gemini", "text": "Call ai.models.generateContent() with the user message and send the response back via sendMessage."},
-        {"@type": "HowToStep", "name": "Add Conversation History", "text": "Use Gemini's multi-turn chat feature to maintain conversation context per user."}
+        {"@type": "HowToStep", "name": "Configurar ambos clientes", "text": "Inicializa WhatsmeowClient con createClient() y Google GenAI con new GoogleGenAI()."},
+        {"@type": "HowToStep", "name": "Manejar mensajes entrantes", "text": "Escucha el evento message, omite los mensajes propios, muestra el indicador de escritura y extrae el texto."},
+        {"@type": "HowToStep", "name": "Enviar a Gemini", "text": "Llama a ai.models.generateContent() con el mensaje del usuario y envía la respuesta de vuelta con sendMessage."},
+        {"@type": "HowToStep", "name": "Agregar historial de conversación", "text": "Usa la función de chat multi-turno de Gemini para mantener el contexto de conversación por usuario."}
       ]
     })}
   </script>
@@ -31,8 +31,8 @@ import {RelatedGuides} from '@site/src/components/RelatedGuides';
     {JSON.stringify({
       "@context": "https://schema.org",
       "@type": "Article",
-      "headline": "How to Connect WhatsApp to Google Gemini",
-      "description": "Build a WhatsApp chatbot powered by Google Gemini using whatsmeow-node and the Google GenAI SDK. Includes conversation history and typing indicators.",
+      "headline": "Cómo Conectar WhatsApp con Google Gemini",
+      "description": "Crea un chatbot de WhatsApp con Google Gemini usando whatsmeow-node y el SDK de Google GenAI. Incluye historial de conversación e indicadores de escritura.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/connect-to-gemini.png",
       "author": {"@type": "Organization", "name": "whatsmeow-node", "url": "https://nicastelo.github.io/whatsmeow-node/"},
       "publisher": {"@type": "Organization", "name": "whatsmeow-node", "logo": {"@type": "ImageObject", "url": "https://nicastelo.github.io/whatsmeow-node/img/image.png"}}

--- a/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/connect-to-gemini.md
+++ b/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/connect-to-gemini.md
@@ -1,0 +1,231 @@
+---
+title: "Cómo Conectar WhatsApp con Google Gemini"
+sidebar_label: Conectar con Gemini
+sidebar_position: 14
+description: "Crea un chatbot de WhatsApp con Google Gemini usando whatsmeow-node y el SDK de Google GenAI. Incluye historial de conversación e indicadores de escritura."
+keywords: [conectar whatsapp gemini, bot whatsapp gemini, bot whatsapp google ai nodejs, integración gemini whatsapp, whatsapp gemini typescript]
+---
+
+import Head from '@docusaurus/Head';
+import {RelatedGuides} from '@site/src/components/RelatedGuides';
+
+<Head>
+  <meta property="og:image" content="https://nicastelo.github.io/whatsmeow-node/img/guides/es/connect-to-gemini.png" />
+  <meta name="twitter:image" content="https://nicastelo.github.io/whatsmeow-node/img/guides/es/connect-to-gemini.png" />
+  <script type="application/ld+json">
+    {JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "HowTo",
+      "name": "How to Connect WhatsApp to Google Gemini",
+      "description": "Build a WhatsApp chatbot powered by Google Gemini using whatsmeow-node and the Google GenAI SDK. Includes conversation history and typing indicators.",
+      "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/connect-to-gemini.png",
+      "step": [
+        {"@type": "HowToStep", "name": "Set Up Both Clients", "text": "Initialize WhatsmeowClient with createClient() and Google GenAI with new GoogleGenAI()."},
+        {"@type": "HowToStep", "name": "Handle Incoming Messages", "text": "Listen for the message event, skip own messages, show typing, and extract text."},
+        {"@type": "HowToStep", "name": "Send to Gemini", "text": "Call ai.models.generateContent() with the user message and send the response back via sendMessage."},
+        {"@type": "HowToStep", "name": "Add Conversation History", "text": "Use Gemini's multi-turn chat feature to maintain conversation context per user."}
+      ]
+    })}
+  </script>
+  <script type="application/ld+json">
+    {JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "Article",
+      "headline": "How to Connect WhatsApp to Google Gemini",
+      "description": "Build a WhatsApp chatbot powered by Google Gemini using whatsmeow-node and the Google GenAI SDK. Includes conversation history and typing indicators.",
+      "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/connect-to-gemini.png",
+      "author": {"@type": "Organization", "name": "whatsmeow-node", "url": "https://nicastelo.github.io/whatsmeow-node/"},
+      "publisher": {"@type": "Organization", "name": "whatsmeow-node", "logo": {"@type": "ImageObject", "url": "https://nicastelo.github.io/whatsmeow-node/img/image.png"}}
+    })}
+  </script>
+</Head>
+
+![Cómo Conectar WhatsApp con Google Gemini](/img/guides/es/connect-to-gemini.png)
+![Cómo Conectar WhatsApp con Google Gemini](/img/guides/es/connect-to-gemini-light.png)
+
+# Cómo Conectar WhatsApp con Google Gemini
+
+Combina whatsmeow-node con el SDK de Google GenAI para crear un chatbot de WhatsApp potenciado por Gemini. Los mensajes entran por WhatsApp, se envían a Gemini para obtener una respuesta, y la respuesta vuelve al usuario — con indicadores de escritura mientras el modelo piensa.
+
+## Requisitos Previos
+
+- Una sesión vinculada de whatsmeow-node ([Cómo Vincular](pair-whatsapp))
+- Una API key de Google AI (configurada como variable de entorno `GEMINI_API_KEY`) — obtén una en [ai.google.dev](https://ai.google.dev/)
+- El SDK de Google GenAI: `npm install @google/genai`
+
+## Paso 1: Configurar Ambos Clientes
+
+```typescript
+import { createClient } from "@whatsmeow-node/whatsmeow-node";
+import { GoogleGenAI } from "@google/genai";
+
+const client = createClient({ store: "session.db" });
+const ai = new GoogleGenAI({ apiKey: process.env.GEMINI_API_KEY });
+
+const SYSTEM_PROMPT = "You are a helpful WhatsApp assistant. Keep responses concise — under 500 characters when possible, since this is a chat interface.";
+```
+
+## Paso 2: Manejar Mensajes Entrantes
+
+```typescript
+client.on("message", async ({ info, message }) => {
+  if (info.isFromMe) return;
+
+  const text =
+    (message.conversation as string) ??
+    (message.extendedTextMessage as { text?: string } | undefined)?.text;
+  if (!text) return;
+
+  await client.sendChatPresence(info.chat, "composing");
+
+  const reply = await askGemini(info.sender, text);
+  await client.sendMessage(info.chat, { conversation: reply });
+});
+```
+
+## Paso 3: Enviar a Gemini
+
+```typescript
+async function askGemini(userJid: string, userMessage: string): Promise<string> {
+  const response = await ai.models.generateContent({
+    model: "gemini-2.5-flash",
+    contents: userMessage,
+    config: {
+      systemInstruction: SYSTEM_PROMPT,
+    },
+  });
+
+  return response.text ?? "I couldn't generate a response.";
+}
+```
+
+## Paso 4: Agregar Historial de Conversación
+
+Gemini soporta chat multi-turno a través de la API `chats.create()`. Almacena una sesión de chat por usuario:
+
+```typescript
+import type { Chat } from "@google/genai";
+
+const chats = new Map<string, Chat>();
+
+function getChat(userJid: string): Chat {
+  let chat = chats.get(userJid);
+  if (!chat) {
+    chat = ai.chats.create({
+      model: "gemini-2.5-flash",
+      config: {
+        systemInstruction: SYSTEM_PROMPT,
+      },
+    });
+    chats.set(userJid, chat);
+  }
+  return chat;
+}
+
+async function askGemini(userJid: string, userMessage: string): Promise<string> {
+  const chat = getChat(userJid);
+  const response = await chat.sendMessage({ message: userMessage });
+  return response.text ?? "I couldn't generate a response.";
+}
+```
+
+## Ejemplo Completo
+
+```typescript
+import { createClient } from "@whatsmeow-node/whatsmeow-node";
+import { GoogleGenAI } from "@google/genai";
+import type { Chat } from "@google/genai";
+
+const client = createClient({ store: "session.db" });
+const ai = new GoogleGenAI({ apiKey: process.env.GEMINI_API_KEY });
+
+const SYSTEM_PROMPT =
+  "You are a helpful WhatsApp assistant. Keep responses concise — under 500 characters when possible, since this is a chat interface.";
+
+const chats = new Map<string, Chat>();
+
+function getChat(userJid: string): Chat {
+  let chat = chats.get(userJid);
+  if (!chat) {
+    chat = ai.chats.create({
+      model: "gemini-2.5-flash",
+      config: {
+        systemInstruction: SYSTEM_PROMPT,
+      },
+    });
+    chats.set(userJid, chat);
+  }
+  return chat;
+}
+
+async function askGemini(userJid: string, userMessage: string): Promise<string> {
+  const chat = getChat(userJid);
+  const response = await chat.sendMessage({ message: userMessage });
+  return response.text ?? "I couldn't generate a response.";
+}
+
+client.on("message", async ({ info, message }) => {
+  if (info.isFromMe) return;
+
+  const text =
+    (message.conversation as string) ??
+    (message.extendedTextMessage as { text?: string } | undefined)?.text;
+  if (!text) return;
+
+  console.log(`${info.pushName}: ${text}`);
+  await client.sendChatPresence(info.chat, "composing");
+
+  try {
+    const reply = await askGemini(info.sender, text);
+    await client.sendMessage(info.chat, { conversation: reply });
+    console.log(`→ ${reply.slice(0, 80)}...`);
+  } catch (err) {
+    console.error("Gemini API error:", err);
+    await client.sendMessage(info.chat, {
+      conversation: "Sorry, I'm having trouble right now. Try again in a moment.",
+    });
+  }
+});
+
+client.on("logged_out", ({ reason }) => {
+  console.error(`Logged out: ${reason}`);
+  client.close();
+  process.exit(1);
+});
+
+async function main() {
+  const { jid } = await client.init();
+  if (!jid) {
+    console.error("Not paired! See: How to Pair WhatsApp");
+    process.exit(1);
+  }
+  await client.connect();
+  await client.sendPresence("available");
+  console.log("Gemini bot is online!");
+
+  process.on("SIGINT", async () => {
+    await client.sendPresence("unavailable");
+    await client.disconnect();
+    client.close();
+    process.exit(0);
+  });
+}
+
+main().catch(console.error);
+```
+
+## Errores Comunes
+
+:::warning Bucles de eco
+Siempre verifica `info.isFromMe` primero. Sin esto, el bot envía un mensaje, ve su propio mensaje, lo envía a Gemini y responde de nuevo — para siempre.
+:::
+
+:::warning Exposición de la API key
+Nunca escribas tu API key directamente en el código. Usa variables de entorno (`GEMINI_API_KEY`) o un archivo `.env` (agregado a `.gitignore`).
+:::
+
+:::warning El historial de chat está en memoria
+Los objetos `Chat` se almacenan en un `Map` y se pierden al reiniciar. Para persistencia, guarda el historial de conversación en una base de datos y recrea los chats con la opción `history`.
+:::
+
+<RelatedGuides slugs={["connect-to-ai", "connect-to-chatgpt", "connect-to-ollama", "connect-to-deepseek"]} />

--- a/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/connect-to-ollama.md
+++ b/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/connect-to-ollama.md
@@ -1,0 +1,250 @@
+---
+title: "Cómo Conectar WhatsApp con Ollama (IA Local)"
+sidebar_label: Conectar con Ollama
+sidebar_position: 16
+description: "Crea un chatbot de WhatsApp con un modelo de IA local usando whatsmeow-node y Ollama. Sin API key — corre completamente en tu máquina."
+keywords: [conectar whatsapp ollama, bot whatsapp ia local, bot whatsapp ollama nodejs, bot whatsapp llama, whatsapp llm local, whatsapp ia autoalojada]
+---
+
+import Head from '@docusaurus/Head';
+import {RelatedGuides} from '@site/src/components/RelatedGuides';
+
+<Head>
+  <meta property="og:image" content="https://nicastelo.github.io/whatsmeow-node/img/guides/es/connect-to-ollama.png" />
+  <meta name="twitter:image" content="https://nicastelo.github.io/whatsmeow-node/img/guides/es/connect-to-ollama.png" />
+  <script type="application/ld+json">
+    {JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "HowTo",
+      "name": "How to Connect WhatsApp to Ollama (Local AI)",
+      "description": "Build a WhatsApp chatbot powered by a local AI model using whatsmeow-node and Ollama. No API key needed — runs entirely on your machine.",
+      "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/connect-to-ollama.png",
+      "step": [
+        {"@type": "HowToStep", "name": "Install Ollama and Pull a Model", "text": "Install Ollama from ollama.com and pull a model like llama3.2 or gemma3."},
+        {"@type": "HowToStep", "name": "Set Up Both Clients", "text": "Initialize WhatsmeowClient with createClient() and Ollama client with new Ollama()."},
+        {"@type": "HowToStep", "name": "Handle Incoming Messages", "text": "Listen for the message event, skip own messages, show typing, and extract text."},
+        {"@type": "HowToStep", "name": "Send to Ollama", "text": "Call ollama.chat() with the user message and send the response back via sendMessage."}
+      ]
+    })}
+  </script>
+  <script type="application/ld+json">
+    {JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "Article",
+      "headline": "How to Connect WhatsApp to Ollama (Local AI)",
+      "description": "Build a WhatsApp chatbot powered by a local AI model using whatsmeow-node and Ollama. No API key needed — runs entirely on your machine.",
+      "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/connect-to-ollama.png",
+      "author": {"@type": "Organization", "name": "whatsmeow-node", "url": "https://nicastelo.github.io/whatsmeow-node/"},
+      "publisher": {"@type": "Organization", "name": "whatsmeow-node", "logo": {"@type": "ImageObject", "url": "https://nicastelo.github.io/whatsmeow-node/img/image.png"}}
+    })}
+  </script>
+</Head>
+
+![Cómo Conectar WhatsApp con Ollama (IA Local)](/img/guides/es/connect-to-ollama.png)
+![Cómo Conectar WhatsApp con Ollama (IA Local)](/img/guides/es/connect-to-ollama-light.png)
+
+# Cómo Conectar WhatsApp con Ollama (IA Local)
+
+Ejecuta tu chatbot de WhatsApp completamente en tu propia máquina — sin API keys, sin costos de nube, sin datos saliendo de tu red. Ollama facilita ejecutar modelos open source como Llama, Gemma y Mistral localmente.
+
+## Requisitos Previos
+
+- Una sesión vinculada de whatsmeow-node ([Cómo Vincular](pair-whatsapp))
+- [Ollama](https://ollama.com/) instalado y corriendo
+- Un modelo descargado: `ollama pull llama3.2`
+- El SDK de Ollama: `npm install ollama`
+
+## Paso 1: Descargar un Modelo
+
+```bash
+# Install Ollama from https://ollama.com, then:
+ollama pull llama3.2
+```
+
+Otras buenas opciones para chat:
+- `gemma3` — modelo abierto de Google, rápido y capaz
+- `mistral` — potente para su tamaño
+- `llama3.2:1b` — el Llama más pequeño, respuestas más rápidas
+
+## Paso 2: Configurar Ambos Clientes
+
+```typescript
+import { createClient } from "@whatsmeow-node/whatsmeow-node";
+import { Ollama } from "ollama";
+
+const client = createClient({ store: "session.db" });
+const ollama = new Ollama({ host: "http://localhost:11434" });
+
+const MODEL = "llama3.2";
+const SYSTEM_PROMPT = "You are a helpful WhatsApp assistant. Keep responses concise — under 500 characters when possible, since this is a chat interface.";
+```
+
+## Paso 3: Manejar Mensajes Entrantes
+
+```typescript
+client.on("message", async ({ info, message }) => {
+  if (info.isFromMe) return;
+
+  const text =
+    (message.conversation as string) ??
+    (message.extendedTextMessage as { text?: string } | undefined)?.text;
+  if (!text) return;
+
+  await client.sendChatPresence(info.chat, "composing");
+
+  const reply = await askOllama(info.sender, text);
+  await client.sendMessage(info.chat, { conversation: reply });
+});
+```
+
+## Paso 4: Enviar a Ollama
+
+```typescript
+async function askOllama(userJid: string, userMessage: string): Promise<string> {
+  const response = await ollama.chat({
+    model: MODEL,
+    messages: [
+      { role: "system", content: SYSTEM_PROMPT },
+      { role: "user", content: userMessage },
+    ],
+  });
+
+  return response.message.content;
+}
+```
+
+## Paso 5: Agregar Historial de Conversación
+
+```typescript
+import type { Message } from "ollama";
+
+const conversations = new Map<string, Message[]>();
+const MAX_HISTORY = 20;
+
+async function askOllama(userJid: string, userMessage: string): Promise<string> {
+  const history = conversations.get(userJid) ?? [];
+  history.push({ role: "user", content: userMessage });
+
+  if (history.length > MAX_HISTORY) {
+    history.splice(0, history.length - MAX_HISTORY);
+  }
+
+  const response = await ollama.chat({
+    model: MODEL,
+    messages: [{ role: "system", content: SYSTEM_PROMPT }, ...history],
+  });
+
+  const reply = response.message.content;
+  history.push({ role: "assistant", content: reply });
+  conversations.set(userJid, history);
+
+  return reply;
+}
+```
+
+## Ejemplo Completo
+
+```typescript
+import { createClient } from "@whatsmeow-node/whatsmeow-node";
+import { Ollama } from "ollama";
+import type { Message } from "ollama";
+
+const client = createClient({ store: "session.db" });
+const ollama = new Ollama({ host: "http://localhost:11434" });
+
+const MODEL = "llama3.2";
+const SYSTEM_PROMPT =
+  "You are a helpful WhatsApp assistant. Keep responses concise — under 500 characters when possible, since this is a chat interface.";
+
+const conversations = new Map<string, Message[]>();
+const MAX_HISTORY = 20;
+
+async function askOllama(userJid: string, userMessage: string): Promise<string> {
+  const history = conversations.get(userJid) ?? [];
+  history.push({ role: "user", content: userMessage });
+
+  if (history.length > MAX_HISTORY) {
+    history.splice(0, history.length - MAX_HISTORY);
+  }
+
+  const response = await ollama.chat({
+    model: MODEL,
+    messages: [{ role: "system", content: SYSTEM_PROMPT }, ...history],
+  });
+
+  const reply = response.message.content;
+  history.push({ role: "assistant", content: reply });
+  conversations.set(userJid, history);
+
+  return reply;
+}
+
+client.on("message", async ({ info, message }) => {
+  if (info.isFromMe) return;
+
+  const text =
+    (message.conversation as string) ??
+    (message.extendedTextMessage as { text?: string } | undefined)?.text;
+  if (!text) return;
+
+  console.log(`${info.pushName}: ${text}`);
+  await client.sendChatPresence(info.chat, "composing");
+
+  try {
+    const reply = await askOllama(info.sender, text);
+    await client.sendMessage(info.chat, { conversation: reply });
+    console.log(`→ ${reply.slice(0, 80)}...`);
+  } catch (err) {
+    console.error("Ollama error:", err);
+    await client.sendMessage(info.chat, {
+      conversation: "Sorry, I'm having trouble right now. Make sure Ollama is running.",
+    });
+  }
+});
+
+client.on("logged_out", ({ reason }) => {
+  console.error(`Logged out: ${reason}`);
+  client.close();
+  process.exit(1);
+});
+
+async function main() {
+  const { jid } = await client.init();
+  if (!jid) {
+    console.error("Not paired! See: How to Pair WhatsApp");
+    process.exit(1);
+  }
+  await client.connect();
+  await client.sendPresence("available");
+  console.log(`Ollama bot is online! (model: ${MODEL})`);
+
+  process.on("SIGINT", async () => {
+    await client.sendPresence("unavailable");
+    await client.disconnect();
+    client.close();
+    process.exit(0);
+  });
+}
+
+main().catch(console.error);
+```
+
+## Errores Comunes
+
+:::warning Ollama debe estar corriendo
+Asegúrate de que el servidor de Ollama esté corriendo (`ollama serve`) antes de iniciar el bot. Si no está corriendo, todas las peticiones van a fallar.
+:::
+
+:::warning El tiempo de respuesta depende del hardware
+Los modelos locales corren en tu CPU/GPU. Modelos más pequeños como `llama3.2:1b` responden en 1-3 segundos en hardware moderno. Modelos más grandes pueden tardar 10+ segundos — el indicador de escritura mantiene informado al usuario mientras espera.
+:::
+
+:::warning Bucles de eco
+Siempre verifica `info.isFromMe` primero. Sin esto, el bot responde a sus propios mensajes para siempre.
+:::
+
+:::warning El modelo debe estar descargado primero
+Ejecuta `ollama pull llama3.2` antes de iniciar el bot. Si el modelo no está descargado, las peticiones van a fallar.
+:::
+
+<RelatedGuides slugs={["connect-to-ai", "connect-to-chatgpt", "connect-to-gemini", "connect-to-deepseek"]} />

--- a/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/connect-to-ollama.md
+++ b/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/connect-to-ollama.md
@@ -16,14 +16,14 @@ import {RelatedGuides} from '@site/src/components/RelatedGuides';
     {JSON.stringify({
       "@context": "https://schema.org",
       "@type": "HowTo",
-      "name": "How to Connect WhatsApp to Ollama (Local AI)",
-      "description": "Build a WhatsApp chatbot powered by a local AI model using whatsmeow-node and Ollama. No API key needed — runs entirely on your machine.",
+      "name": "Cómo Conectar WhatsApp con Ollama (IA Local)",
+      "description": "Crea un chatbot de WhatsApp con un modelo de IA local usando whatsmeow-node y Ollama. Sin API key — corre completamente en tu máquina.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/connect-to-ollama.png",
       "step": [
-        {"@type": "HowToStep", "name": "Install Ollama and Pull a Model", "text": "Install Ollama from ollama.com and pull a model like llama3.2 or gemma3."},
-        {"@type": "HowToStep", "name": "Set Up Both Clients", "text": "Initialize WhatsmeowClient with createClient() and Ollama client with new Ollama()."},
-        {"@type": "HowToStep", "name": "Handle Incoming Messages", "text": "Listen for the message event, skip own messages, show typing, and extract text."},
-        {"@type": "HowToStep", "name": "Send to Ollama", "text": "Call ollama.chat() with the user message and send the response back via sendMessage."}
+        {"@type": "HowToStep", "name": "Instalar Ollama y descargar un modelo", "text": "Instala Ollama desde ollama.com y descarga un modelo como llama3.2 o gemma3."},
+        {"@type": "HowToStep", "name": "Configurar ambos clientes", "text": "Inicializa WhatsmeowClient con createClient() y el cliente de Ollama con new Ollama()."},
+        {"@type": "HowToStep", "name": "Manejar mensajes entrantes", "text": "Escucha el evento message, omite los mensajes propios, muestra el indicador de escritura y extrae el texto."},
+        {"@type": "HowToStep", "name": "Enviar a Ollama", "text": "Llama a ollama.chat() con el mensaje del usuario y envía la respuesta de vuelta con sendMessage."}
       ]
     })}
   </script>
@@ -31,8 +31,8 @@ import {RelatedGuides} from '@site/src/components/RelatedGuides';
     {JSON.stringify({
       "@context": "https://schema.org",
       "@type": "Article",
-      "headline": "How to Connect WhatsApp to Ollama (Local AI)",
-      "description": "Build a WhatsApp chatbot powered by a local AI model using whatsmeow-node and Ollama. No API key needed — runs entirely on your machine.",
+      "headline": "Cómo Conectar WhatsApp con Ollama (IA Local)",
+      "description": "Crea un chatbot de WhatsApp con un modelo de IA local usando whatsmeow-node y Ollama. Sin API key — corre completamente en tu máquina.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/connect-to-ollama.png",
       "author": {"@type": "Organization", "name": "whatsmeow-node", "url": "https://nicastelo.github.io/whatsmeow-node/"},
       "publisher": {"@type": "Organization", "name": "whatsmeow-node", "logo": {"@type": "ImageObject", "url": "https://nicastelo.github.io/whatsmeow-node/img/image.png"}}

--- a/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/download-media.md
+++ b/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/download-media.md
@@ -19,10 +19,10 @@ import Head from '@docusaurus/Head';
       "description": "Descarga y guarda imágenes, videos, audio, documentos y stickers de WhatsApp en disco con Node.js usando whatsmeow-node.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/download-media.png",
       "step": [
-        {"@type": "HowToStep", "name": "Listen for Incoming Messages", "text": "Subscribe to the message event and filter for media messages."},
-        {"@type": "HowToStep", "name": "Detect the Media Type", "text": "Check for imageMessage, videoMessage, audioMessage, documentMessage, or stickerMessage fields."},
-        {"@type": "HowToStep", "name": "Download with downloadAny()", "text": "Call downloadAny(message) to decrypt and save media to a temporary file."},
-        {"@type": "HowToStep", "name": "Save to a Permanent Location", "text": "Copy the temp file to a permanent directory using fs.copyFile()."}
+        {"@type": "HowToStep", "name": "Escuchar mensajes entrantes", "text": "Suscríbete al evento message y filtra los mensajes multimedia."},
+        {"@type": "HowToStep", "name": "Detectar el tipo de multimedia", "text": "Verifica si existen los campos imageMessage, videoMessage, audioMessage, documentMessage o stickerMessage."},
+        {"@type": "HowToStep", "name": "Descargar con downloadAny()", "text": "Llama a downloadAny(message) para desencriptar y guardar el archivo multimedia en un archivo temporal."},
+        {"@type": "HowToStep", "name": "Guardar en una ubicación permanente", "text": "Copia el archivo temporal a un directorio permanente usando fs.copyFile()."}
       ]
     })}
   </script>

--- a/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/forward-messages.md
+++ b/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/forward-messages.md
@@ -1,0 +1,305 @@
+---
+title: "Cómo Reenviar Mensajes de WhatsApp Programáticamente"
+sidebar_label: Reenviar Mensajes
+sidebar_position: 20
+description: "Reenvía mensajes de WhatsApp entre chats programáticamente con Node.js — texto, multimedia y mensajes de grupo usando whatsmeow-node."
+keywords: [reenviar mensajes whatsapp api, whatsapp reenviar mensaje nodejs, bot reenvío whatsapp, reenviar mensajes whatsapp programáticamente, bot relay whatsapp]
+---
+
+import Head from '@docusaurus/Head';
+import {RelatedGuides} from '@site/src/components/RelatedGuides';
+
+<Head>
+  <meta property="og:image" content="https://nicastelo.github.io/whatsmeow-node/img/guides/es/forward-messages.png" />
+  <meta name="twitter:image" content="https://nicastelo.github.io/whatsmeow-node/img/guides/es/forward-messages.png" />
+  <script type="application/ld+json">
+    {JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "HowTo",
+      "name": "How to Forward WhatsApp Messages Programmatically",
+      "description": "Forward WhatsApp messages between chats programmatically with Node.js — text, media, and group messages using whatsmeow-node.",
+      "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/forward-messages.png",
+      "step": [
+        {"@type": "HowToStep", "name": "Listen for Messages", "text": "Subscribe to the message event and filter for messages you want to forward."},
+        {"@type": "HowToStep", "name": "Forward Text Messages", "text": "Use sendRawMessage with the original message content and isForwarded flag in contextInfo."},
+        {"@type": "HowToStep", "name": "Forward Media Messages", "text": "Pass the original media message directly — no need to re-upload."},
+        {"@type": "HowToStep", "name": "Build a Relay Bot", "text": "Forward messages between a group and a private chat, or between multiple groups."}
+      ]
+    })}
+  </script>
+  <script type="application/ld+json">
+    {JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "Article",
+      "headline": "How to Forward WhatsApp Messages Programmatically",
+      "description": "Forward WhatsApp messages between chats programmatically with Node.js — text, media, and group messages using whatsmeow-node.",
+      "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/forward-messages.png",
+      "author": {"@type": "Organization", "name": "whatsmeow-node", "url": "https://nicastelo.github.io/whatsmeow-node/"},
+      "publisher": {"@type": "Organization", "name": "whatsmeow-node", "logo": {"@type": "ImageObject", "url": "https://nicastelo.github.io/whatsmeow-node/img/image.png"}}
+    })}
+  </script>
+</Head>
+
+![Cómo Reenviar Mensajes de WhatsApp Programáticamente](/img/guides/es/forward-messages.png)
+![Cómo Reenviar Mensajes de WhatsApp Programáticamente](/img/guides/es/forward-messages-light.png)
+
+# Cómo Reenviar Mensajes de WhatsApp Programáticamente
+
+Reenvía mensajes entre chats de WhatsApp usando `sendRawMessage()`. Puedes reenviar texto, multimedia, encuestas y cualquier otro tipo de mensaje — con o sin la etiqueta "Reenviado".
+
+## Requisitos Previos
+
+- Una sesión vinculada de whatsmeow-node ([Cómo Vincular](pair-whatsapp))
+
+## Reenviar un Mensaje de Texto
+
+Para reenviar un mensaje recibido a otro chat, pásalo vía `sendRawMessage` con el flag `isForwarded`:
+
+```typescript
+const targetJid = "5598765432@s.whatsapp.net";
+
+client.on("message", async ({ info, message }) => {
+  if (info.isFromMe) return;
+
+  const text =
+    (message.conversation as string) ??
+    (message.extendedTextMessage as { text?: string } | undefined)?.text;
+  if (!text) return;
+
+  // Forward as a new message with the "Forwarded" label
+  await client.sendRawMessage(targetJid, {
+    extendedTextMessage: {
+      text,
+      contextInfo: {
+        isForwarded: true,
+        forwardingScore: 1,
+      },
+    },
+  });
+});
+```
+
+El flag `isForwarded: true` muestra la etiqueta "Reenviado" en el mensaje. `forwardingScore` rastrea cuántas veces se ha reenviado el mensaje — WhatsApp muestra "Reenviado muchas veces" cuando llega a 4+.
+
+## Reenviar Sin la Etiqueta "Reenviado"
+
+Para retransmitir un mensaje sin la etiqueta de reenvío, simplemente envíalo como mensaje nuevo:
+
+```typescript
+// Send as if it's a new message — no forwarding label
+await client.sendMessage(targetJid, { conversation: text });
+```
+
+## Reenviar Mensajes Multimedia
+
+Los mensajes multimedia (imágenes, videos, documentos) se pueden reenviar pasando el contenido del mensaje original. La multimedia ya está subida a los servidores de WhatsApp, así que no se necesita re-subir:
+
+```typescript
+client.on("message", async ({ info, message }) => {
+  if (info.isFromMe) return;
+
+  // Forward images
+  if (message.imageMessage) {
+    await client.sendRawMessage(targetJid, {
+      imageMessage: {
+        ...message.imageMessage,
+        contextInfo: {
+          isForwarded: true,
+          forwardingScore: 1,
+        },
+      },
+    });
+    return;
+  }
+
+  // Forward videos
+  if (message.videoMessage) {
+    await client.sendRawMessage(targetJid, {
+      videoMessage: {
+        ...message.videoMessage,
+        contextInfo: {
+          isForwarded: true,
+          forwardingScore: 1,
+        },
+      },
+    });
+    return;
+  }
+
+  // Forward documents
+  if (message.documentMessage) {
+    await client.sendRawMessage(targetJid, {
+      documentMessage: {
+        ...message.documentMessage,
+        contextInfo: {
+          isForwarded: true,
+          forwardingScore: 1,
+        },
+      },
+    });
+    return;
+  }
+});
+```
+
+## Reenviar Cualquier Tipo de Mensaje
+
+Una función genérica que reenvía cualquier mensaje detectando su tipo:
+
+```typescript
+const MESSAGE_TYPES = [
+  "conversation",
+  "extendedTextMessage",
+  "imageMessage",
+  "videoMessage",
+  "audioMessage",
+  "documentMessage",
+  "stickerMessage",
+  "contactMessage",
+  "locationMessage",
+  "pollCreationMessage",
+] as const;
+
+async function forwardMessage(
+  targetJid: string,
+  message: Record<string, unknown>,
+  showForwarded = true,
+) {
+  for (const type of MESSAGE_TYPES) {
+    if (!(type in message)) continue;
+
+    if (type === "conversation") {
+      // Simple text — wrap in extendedTextMessage for contextInfo support
+      await client.sendRawMessage(targetJid, {
+        extendedTextMessage: {
+          text: message.conversation as string,
+          ...(showForwarded && {
+            contextInfo: { isForwarded: true, forwardingScore: 1 },
+          }),
+        },
+      });
+    } else {
+      // Structured message — spread and add contextInfo
+      const content = message[type] as Record<string, unknown>;
+      await client.sendRawMessage(targetJid, {
+        [type]: {
+          ...content,
+          ...(showForwarded && {
+            contextInfo: {
+              ...(content.contextInfo as Record<string, unknown> ?? {}),
+              isForwarded: true,
+              forwardingScore: 1,
+            },
+          }),
+        },
+      });
+    }
+    return;
+  }
+}
+```
+
+## Crear un Bot Relay
+
+Reenvía todos los mensajes de un grupo a otro:
+
+```typescript
+const SOURCE_GROUP = "120363XXXXX@g.us";
+const TARGET_GROUP = "120363YYYYY@g.us";
+
+client.on("message", async ({ info, message }) => {
+  if (info.isFromMe) return;
+  if (info.chat !== SOURCE_GROUP) return;
+
+  // Add sender attribution
+  const attribution = `[${info.pushName}]:\n`;
+
+  const text =
+    (message.conversation as string) ??
+    (message.extendedTextMessage as { text?: string } | undefined)?.text;
+
+  if (text) {
+    await client.sendMessage(TARGET_GROUP, {
+      conversation: `${attribution}${text}`,
+    });
+    return;
+  }
+
+  // Forward media with caption attribution
+  await forwardMessage(TARGET_GROUP, message);
+});
+```
+
+## Ejemplo Completo
+
+Un bot relay que reenvía mensajes entre un chat privado y un grupo:
+
+```typescript
+import { createClient } from "@whatsmeow-node/whatsmeow-node";
+
+const client = createClient({ store: "session.db" });
+
+// Forward messages FROM this chat TO the group
+const PRIVATE_CHAT = "5512345678@s.whatsapp.net";
+const GROUP_CHAT = "120363XXXXX@g.us";
+
+client.on("message", async ({ info, message }) => {
+  if (info.isFromMe) return;
+
+  const text =
+    (message.conversation as string) ??
+    (message.extendedTextMessage as { text?: string } | undefined)?.text;
+
+  // Private → Group
+  if (info.chat === PRIVATE_CHAT && text) {
+    await client.sendMessage(GROUP_CHAT, {
+      conversation: `[${info.pushName}]: ${text}`,
+    });
+    return;
+  }
+
+  // Group → Private
+  if (info.chat === GROUP_CHAT && text) {
+    await client.sendMessage(PRIVATE_CHAT, {
+      conversation: `[${info.pushName} in group]: ${text}`,
+    });
+    return;
+  }
+});
+
+async function main() {
+  const { jid } = await client.init();
+  if (!jid) {
+    console.error("Not paired!");
+    process.exit(1);
+  }
+  await client.connect();
+  await client.sendPresence("available");
+  console.log("Relay bot is online!");
+
+  process.on("SIGINT", async () => {
+    await client.sendPresence("unavailable");
+    await client.disconnect();
+    client.close();
+    process.exit(0);
+  });
+}
+
+main().catch(console.error);
+```
+
+## Errores Comunes
+
+:::warning Bucles de eco
+Si reenvías mensajes de un chat y también escuchas el chat destino, puedes crear un bucle infinito. Siempre verifica el chat de origen y omite tus propios mensajes.
+:::
+
+:::warning Expiración de multimedia
+Las URLs de multimedia de WhatsApp expiran después de un tiempo. Si guardas un mensaje e intentas reenviarlo mucho después, la multimedia puede ya no estar disponible. Reenvía la multimedia rápidamente o descárgala primero con `downloadAny()`.
+:::
+
+:::warning Límites de tasa
+Reenviar muchos mensajes rápidamente va a alcanzar los límites de tasa de WhatsApp. Espacia los envíos, especialmente para operaciones de relay masivo. Consulta [Límites de Tasa](/docs/rate-limiting).
+:::
+
+<RelatedGuides slugs={["build-a-bot", "download-media", "automate-group-messages"]} />

--- a/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/forward-messages.md
+++ b/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/forward-messages.md
@@ -16,14 +16,14 @@ import {RelatedGuides} from '@site/src/components/RelatedGuides';
     {JSON.stringify({
       "@context": "https://schema.org",
       "@type": "HowTo",
-      "name": "How to Forward WhatsApp Messages Programmatically",
-      "description": "Forward WhatsApp messages between chats programmatically with Node.js — text, media, and group messages using whatsmeow-node.",
+      "name": "Cómo Reenviar Mensajes de WhatsApp Programáticamente",
+      "description": "Reenvía mensajes de WhatsApp entre chats programáticamente con Node.js — texto, multimedia y mensajes de grupo usando whatsmeow-node.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/forward-messages.png",
       "step": [
-        {"@type": "HowToStep", "name": "Listen for Messages", "text": "Subscribe to the message event and filter for messages you want to forward."},
-        {"@type": "HowToStep", "name": "Forward Text Messages", "text": "Use sendRawMessage with the original message content and isForwarded flag in contextInfo."},
-        {"@type": "HowToStep", "name": "Forward Media Messages", "text": "Pass the original media message directly — no need to re-upload."},
-        {"@type": "HowToStep", "name": "Build a Relay Bot", "text": "Forward messages between a group and a private chat, or between multiple groups."}
+        {"@type": "HowToStep", "name": "Escuchar mensajes", "text": "Suscríbete al evento message y filtra los mensajes que quieres reenviar."},
+        {"@type": "HowToStep", "name": "Reenviar mensajes de texto", "text": "Usa sendRawMessage con el contenido del mensaje original y el flag isForwarded en contextInfo."},
+        {"@type": "HowToStep", "name": "Reenviar mensajes multimedia", "text": "Pasa el mensaje multimedia original directamente — no es necesario volver a subirlo."},
+        {"@type": "HowToStep", "name": "Crear un bot relay", "text": "Reenvía mensajes entre un grupo y un chat privado, o entre múltiples grupos."}
       ]
     })}
   </script>
@@ -31,8 +31,8 @@ import {RelatedGuides} from '@site/src/components/RelatedGuides';
     {JSON.stringify({
       "@context": "https://schema.org",
       "@type": "Article",
-      "headline": "How to Forward WhatsApp Messages Programmatically",
-      "description": "Forward WhatsApp messages between chats programmatically with Node.js — text, media, and group messages using whatsmeow-node.",
+      "headline": "Cómo Reenviar Mensajes de WhatsApp Programáticamente",
+      "description": "Reenvía mensajes de WhatsApp entre chats programáticamente con Node.js — texto, multimedia y mensajes de grupo usando whatsmeow-node.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/forward-messages.png",
       "author": {"@type": "Organization", "name": "whatsmeow-node", "url": "https://nicastelo.github.io/whatsmeow-node/"},
       "publisher": {"@type": "Organization", "name": "whatsmeow-node", "logo": {"@type": "ImageObject", "url": "https://nicastelo.github.io/whatsmeow-node/img/image.png"}}

--- a/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/integrate-chatwoot.md
+++ b/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/integrate-chatwoot.md
@@ -1,0 +1,257 @@
+---
+title: "Cómo Usar whatsmeow-node con Chatwoot"
+sidebar_label: Integración con Chatwoot
+sidebar_position: 23
+description: "Conecta whatsmeow-node a Chatwoot como canal de WhatsApp — recibe y responde mensajes de WhatsApp desde el dashboard de agentes de Chatwoot sin la Cloud API oficial."
+keywords: [chatwoot whatsapp, chatwoot whatsmeow, chatwoot whatsapp gratis, chatwoot whatsapp sin cloud api, chatwoot integración whatsapp, chatwoot whatsapp nodejs]
+---
+
+import Head from '@docusaurus/Head';
+import {RelatedGuides} from '@site/src/components/RelatedGuides';
+
+<Head>
+  <meta property="og:image" content="https://nicastelo.github.io/whatsmeow-node/img/guides/es/integrate-chatwoot.png" />
+  <meta name="twitter:image" content="https://nicastelo.github.io/whatsmeow-node/img/guides/es/integrate-chatwoot.png" />
+  <script type="application/ld+json">
+    {JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "HowTo",
+      "name": "How to Use whatsmeow-node with Chatwoot",
+      "description": "Connect whatsmeow-node to Chatwoot as a WhatsApp channel — receive and reply to WhatsApp messages from the Chatwoot agent dashboard without the official Cloud API.",
+      "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/integrate-chatwoot.png",
+      "step": [
+        {"@type": "HowToStep", "name": "Create a Chatwoot API Channel", "text": "Set up an API channel in Chatwoot to receive messages via webhook and send via API."},
+        {"@type": "HowToStep", "name": "Build the whatsmeow-node Bridge", "text": "Create a service that forwards WhatsApp messages to Chatwoot and Chatwoot replies to WhatsApp."},
+        {"@type": "HowToStep", "name": "Forward Messages to Chatwoot", "text": "POST incoming WhatsApp messages to Chatwoot's API as incoming messages on the channel."},
+        {"@type": "HowToStep", "name": "Handle Chatwoot Outgoing Webhooks", "text": "Listen for Chatwoot's message_created webhook and send agent replies via whatsmeow-node."}
+      ]
+    })}
+  </script>
+  <script type="application/ld+json">
+    {JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "Article",
+      "headline": "How to Use whatsmeow-node with Chatwoot",
+      "description": "Connect whatsmeow-node to Chatwoot as a WhatsApp channel — receive and reply to WhatsApp messages from the Chatwoot agent dashboard without the official Cloud API.",
+      "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/integrate-chatwoot.png",
+      "author": {"@type": "Organization", "name": "whatsmeow-node", "url": "https://nicastelo.github.io/whatsmeow-node/"},
+      "publisher": {"@type": "Organization", "name": "whatsmeow-node", "logo": {"@type": "ImageObject", "url": "https://nicastelo.github.io/whatsmeow-node/img/image.png"}}
+    })}
+  </script>
+</Head>
+
+![Cómo Usar whatsmeow-node con Chatwoot](/img/guides/es/integrate-chatwoot.png)
+![Cómo Usar whatsmeow-node con Chatwoot](/img/guides/es/integrate-chatwoot-light.png)
+
+# Cómo Usar whatsmeow-node con Chatwoot
+
+[Chatwoot](https://www.chatwoot.com) es una plataforma de soporte al cliente open source — como Intercom o Zendesk. Su integración de WhatsApp integrada requiere la Cloud API oficial (verificación de Meta Business, precio por mensaje). Con whatsmeow-node y el canal API de Chatwoot, puedes conectar WhatsApp gratis.
+
+## Cómo Funciona
+
+```
+WhatsApp User
+  ↕
+whatsmeow-node Bridge (Express)
+  ↕ Chatwoot API
+Chatwoot Dashboard (agents reply here)
+```
+
+El puente se ubica entre WhatsApp y Chatwoot:
+- **Entrante**: Mensaje de WhatsApp → whatsmeow-node → API de Chatwoot (crea conversación)
+- **Saliente**: El agente responde en Chatwoot → webhook → puente → whatsmeow-node → WhatsApp
+
+## Requisitos Previos
+
+- Una sesión vinculada de whatsmeow-node ([Cómo Vincular](pair-whatsapp))
+- Chatwoot corriendo (autoalojado o en la nube)
+- Express: `npm install express`
+
+## Paso 1: Crear un Canal API en Chatwoot
+
+1. En Chatwoot, ve a **Settings → Inboxes → Add Inbox**
+2. Selecciona **API** como tipo de canal
+3. Nómbralo "WhatsApp" y guarda
+4. Anota el **Inbox ID** y genera un **API access token** desde Settings → Account Settings
+
+Configúralos como variables de entorno:
+
+```bash
+CHATWOOT_URL=http://localhost:3001        # Your Chatwoot URL
+CHATWOOT_API_TOKEN=your_api_token
+CHATWOOT_ACCOUNT_ID=1
+CHATWOOT_INBOX_ID=1
+```
+
+## Paso 2: Configurar el Webhook de Chatwoot
+
+En Chatwoot, ve a **Settings → Integrations → Webhooks**:
+- **URL**: `http://localhost:3000/chatwoot/webhook` (tu servidor puente)
+- **Events**: Selecciona `message_created`
+
+Esto le dice a Chatwoot que envíe las respuestas de los agentes por POST a tu puente.
+
+## Paso 3: Construir el Puente
+
+```typescript
+import { createClient } from "@whatsmeow-node/whatsmeow-node";
+import express from "express";
+
+const client = createClient({ store: "session.db" });
+const app = express();
+app.use(express.json());
+
+const CHATWOOT_URL = process.env.CHATWOOT_URL!;
+const CHATWOOT_API_TOKEN = process.env.CHATWOOT_API_TOKEN!;
+const CHATWOOT_ACCOUNT_ID = process.env.CHATWOOT_ACCOUNT_ID!;
+const CHATWOOT_INBOX_ID = process.env.CHATWOOT_INBOX_ID!;
+
+// Map WhatsApp JID → Chatwoot contact ID + conversation ID
+const contactMap = new Map<string, { contactId: number; conversationId: number }>();
+
+// --- Helper: Chatwoot API call ---
+async function chatwootAPI(path: string, method: string, body?: unknown) {
+  const res = await fetch(`${CHATWOOT_URL}/api/v1/accounts/${CHATWOOT_ACCOUNT_ID}${path}`, {
+    method,
+    headers: {
+      "Content-Type": "application/json",
+      api_access_token: CHATWOOT_API_TOKEN,
+    },
+    ...(body && { body: JSON.stringify(body) }),
+  });
+  return res.json();
+}
+
+// --- Find or create Chatwoot contact ---
+async function getOrCreateContact(jid: string, name: string) {
+  const cached = contactMap.get(jid);
+  if (cached) return cached;
+
+  const phone = jid.split("@")[0];
+
+  // Search for existing contact
+  const search = await chatwootAPI(`/contacts/search?q=${phone}`, "GET");
+  let contactId: number;
+
+  if (search.payload?.length > 0) {
+    contactId = search.payload[0].id;
+  } else {
+    // Create new contact
+    const created = await chatwootAPI("/contacts", "POST", {
+      name: name || phone,
+      phone_number: `+${phone}`,
+      inbox_id: CHATWOOT_INBOX_ID,
+    });
+    contactId = created.payload?.contact?.id ?? created.id;
+  }
+
+  // Find or create conversation
+  const convos = await chatwootAPI(`/contacts/${contactId}/conversations`, "GET");
+  let conversationId: number;
+
+  const openConvo = convos.payload?.find(
+    (c: { inbox_id: number; status: string }) =>
+      c.inbox_id === Number(CHATWOOT_INBOX_ID) && c.status !== "resolved",
+  );
+
+  if (openConvo) {
+    conversationId = openConvo.id;
+  } else {
+    const created = await chatwootAPI("/conversations", "POST", {
+      contact_id: contactId,
+      inbox_id: CHATWOOT_INBOX_ID,
+    });
+    conversationId = created.id;
+  }
+
+  const mapping = { contactId, conversationId };
+  contactMap.set(jid, mapping);
+  return mapping;
+}
+
+// --- Forward WhatsApp messages to Chatwoot ---
+client.on("message", async ({ info, message }) => {
+  if (info.isFromMe || info.isGroup) return;
+
+  const text =
+    (message.conversation as string) ??
+    (message.extendedTextMessage as { text?: string } | undefined)?.text;
+  if (!text) return;
+
+  try {
+    const { conversationId } = await getOrCreateContact(info.sender, info.pushName);
+
+    await chatwootAPI(`/conversations/${conversationId}/messages`, "POST", {
+      content: text,
+      message_type: "incoming",
+    });
+  } catch (err) {
+    console.error("Failed to forward to Chatwoot:", err);
+  }
+});
+
+// --- Handle Chatwoot agent replies ---
+app.post("/chatwoot/webhook", async (req, res) => {
+  const { event, message_type, conversation, content } = req.body;
+
+  // Only handle outgoing messages from agents
+  if (event !== "message_created" || message_type !== "outgoing") {
+    return res.sendStatus(200);
+  }
+
+  // Find the WhatsApp JID for this conversation
+  const jid = [...contactMap.entries()].find(
+    ([, v]) => v.conversationId === conversation?.id,
+  )?.[0];
+
+  if (!jid || !content) return res.sendStatus(200);
+
+  try {
+    await client.sendMessage(jid, { conversation: content });
+  } catch (err) {
+    console.error("Failed to send WhatsApp reply:", err);
+  }
+
+  res.sendStatus(200);
+});
+
+async function main() {
+  const { jid } = await client.init();
+  if (!jid) {
+    console.error("Not paired!");
+    process.exit(1);
+  }
+  await client.connect();
+  await client.sendPresence("available");
+  app.listen(3000, () => console.log("Chatwoot bridge on :3000"));
+}
+
+main().catch(console.error);
+```
+
+## Cómo lo Usan los Agentes
+
+Una vez conectado:
+
+1. Los usuarios de WhatsApp envían un mensaje
+2. Aparece en Chatwoot como una nueva conversación
+3. Los agentes responden desde el dashboard de Chatwoot — igual que con cualquier otro canal
+4. La respuesta vuelve a WhatsApp a través del puente
+
+Los agentes no necesitan saber sobre whatsmeow-node — simplemente usan Chatwoot normalmente.
+
+## Errores Comunes
+
+:::warning El mapa de contactos está en memoria
+El ejemplo almacena el mapeo JID → contacto de Chatwoot en un `Map`. Para producción, persiste esto en una base de datos para que sobreviva a los reinicios.
+:::
+
+:::warning La URL del webhook debe ser accesible
+Chatwoot necesita alcanzar el endpoint de webhook de tu puente. Si corres en Docker, usa el nombre del contenedor o una red compartida.
+:::
+
+:::warning Mensajes de grupo
+Este ejemplo omite los mensajes de grupo (`info.isGroup`). Si necesitas soporte de grupos, tendrás que mapear los JID de grupo a conversaciones de Chatwoot de forma diferente.
+:::
+
+<RelatedGuides slugs={["integrate-whaticket", "integrate-n8n", "send-notifications", "build-a-bot"]} />

--- a/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/integrate-chatwoot.md
+++ b/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/integrate-chatwoot.md
@@ -16,14 +16,14 @@ import {RelatedGuides} from '@site/src/components/RelatedGuides';
     {JSON.stringify({
       "@context": "https://schema.org",
       "@type": "HowTo",
-      "name": "How to Use whatsmeow-node with Chatwoot",
-      "description": "Connect whatsmeow-node to Chatwoot as a WhatsApp channel — receive and reply to WhatsApp messages from the Chatwoot agent dashboard without the official Cloud API.",
+      "name": "Cómo Usar whatsmeow-node con Chatwoot",
+      "description": "Conecta whatsmeow-node a Chatwoot como canal de WhatsApp — recibe y responde mensajes de WhatsApp desde el dashboard de agentes de Chatwoot sin la Cloud API oficial.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/integrate-chatwoot.png",
       "step": [
-        {"@type": "HowToStep", "name": "Create a Chatwoot API Channel", "text": "Set up an API channel in Chatwoot to receive messages via webhook and send via API."},
-        {"@type": "HowToStep", "name": "Build the whatsmeow-node Bridge", "text": "Create a service that forwards WhatsApp messages to Chatwoot and Chatwoot replies to WhatsApp."},
-        {"@type": "HowToStep", "name": "Forward Messages to Chatwoot", "text": "POST incoming WhatsApp messages to Chatwoot's API as incoming messages on the channel."},
-        {"@type": "HowToStep", "name": "Handle Chatwoot Outgoing Webhooks", "text": "Listen for Chatwoot's message_created webhook and send agent replies via whatsmeow-node."}
+        {"@type": "HowToStep", "name": "Crear un canal API en Chatwoot", "text": "Configura un canal API en Chatwoot para recibir mensajes vía webhook y enviar vía API."},
+        {"@type": "HowToStep", "name": "Construir el puente de whatsmeow-node", "text": "Crea un servicio que reenvíe mensajes de WhatsApp a Chatwoot y las respuestas de Chatwoot a WhatsApp."},
+        {"@type": "HowToStep", "name": "Reenviar mensajes a Chatwoot", "text": "Envía por POST los mensajes entrantes de WhatsApp a la API de Chatwoot como mensajes entrantes en el canal."},
+        {"@type": "HowToStep", "name": "Manejar webhooks salientes de Chatwoot", "text": "Escucha el webhook message_created de Chatwoot y envía las respuestas de los agentes vía whatsmeow-node."}
       ]
     })}
   </script>
@@ -31,8 +31,8 @@ import {RelatedGuides} from '@site/src/components/RelatedGuides';
     {JSON.stringify({
       "@context": "https://schema.org",
       "@type": "Article",
-      "headline": "How to Use whatsmeow-node with Chatwoot",
-      "description": "Connect whatsmeow-node to Chatwoot as a WhatsApp channel — receive and reply to WhatsApp messages from the Chatwoot agent dashboard without the official Cloud API.",
+      "headline": "Cómo Usar whatsmeow-node con Chatwoot",
+      "description": "Conecta whatsmeow-node a Chatwoot como canal de WhatsApp — recibe y responde mensajes de WhatsApp desde el dashboard de agentes de Chatwoot sin la Cloud API oficial.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/integrate-chatwoot.png",
       "author": {"@type": "Organization", "name": "whatsmeow-node", "url": "https://nicastelo.github.io/whatsmeow-node/"},
       "publisher": {"@type": "Organization", "name": "whatsmeow-node", "logo": {"@type": "ImageObject", "url": "https://nicastelo.github.io/whatsmeow-node/img/image.png"}}

--- a/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/integrate-n8n.md
+++ b/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/integrate-n8n.md
@@ -16,14 +16,14 @@ import {RelatedGuides} from '@site/src/components/RelatedGuides';
     {JSON.stringify({
       "@context": "https://schema.org",
       "@type": "HowTo",
-      "name": "How to Use whatsmeow-node with n8n",
-      "description": "Connect whatsmeow-node to n8n for WhatsApp workflow automation — send messages, receive webhooks, and build automated flows without the official Cloud API.",
+      "name": "Cómo Usar whatsmeow-node con n8n",
+      "description": "Conecta whatsmeow-node a n8n para automatización de flujos de WhatsApp — envía mensajes, recibe webhooks y crea flujos automatizados sin la Cloud API oficial.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/integrate-n8n.png",
       "step": [
-        {"@type": "HowToStep", "name": "Create a whatsmeow-node REST API", "text": "Wrap whatsmeow-node in an Express server with send and webhook endpoints."},
-        {"@type": "HowToStep", "name": "Forward Messages to n8n", "text": "POST incoming WhatsApp messages to an n8n webhook trigger URL."},
-        {"@type": "HowToStep", "name": "Send Messages from n8n", "text": "Use n8n's HTTP Request node to call the whatsmeow-node REST API."},
-        {"@type": "HowToStep", "name": "Build Automated Flows", "text": "Create n8n workflows that process messages, query databases, call APIs, and reply."}
+        {"@type": "HowToStep", "name": "Crear una API REST de whatsmeow-node", "text": "Envuelve whatsmeow-node en un servidor Express con endpoints de envío y webhook."},
+        {"@type": "HowToStep", "name": "Reenviar mensajes a n8n", "text": "Envía por POST los mensajes entrantes de WhatsApp a una URL de trigger webhook de n8n."},
+        {"@type": "HowToStep", "name": "Enviar mensajes desde n8n", "text": "Usa el nodo HTTP Request de n8n para llamar a la API REST de whatsmeow-node."},
+        {"@type": "HowToStep", "name": "Construir flujos automatizados", "text": "Crea flujos de trabajo en n8n que procesen mensajes, consulten bases de datos, llamen APIs y respondan."}
       ]
     })}
   </script>
@@ -31,8 +31,8 @@ import {RelatedGuides} from '@site/src/components/RelatedGuides';
     {JSON.stringify({
       "@context": "https://schema.org",
       "@type": "Article",
-      "headline": "How to Use whatsmeow-node with n8n",
-      "description": "Connect whatsmeow-node to n8n for WhatsApp workflow automation — send messages, receive webhooks, and build automated flows without the official Cloud API.",
+      "headline": "Cómo Usar whatsmeow-node con n8n",
+      "description": "Conecta whatsmeow-node a n8n para automatización de flujos de WhatsApp — envía mensajes, recibe webhooks y crea flujos automatizados sin la Cloud API oficial.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/integrate-n8n.png",
       "author": {"@type": "Organization", "name": "whatsmeow-node", "url": "https://nicastelo.github.io/whatsmeow-node/"},
       "publisher": {"@type": "Organization", "name": "whatsmeow-node", "logo": {"@type": "ImageObject", "url": "https://nicastelo.github.io/whatsmeow-node/img/image.png"}}

--- a/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/integrate-n8n.md
+++ b/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/integrate-n8n.md
@@ -1,0 +1,252 @@
+---
+title: "Cómo Usar whatsmeow-node con n8n"
+sidebar_label: Integración con n8n
+sidebar_position: 22
+description: "Conecta whatsmeow-node a n8n para automatización de flujos de WhatsApp — envía mensajes, recibe webhooks y crea flujos automatizados sin la Cloud API oficial."
+keywords: [whatsmeow-node n8n, n8n bot whatsapp, n8n integración whatsapp, n8n whatsapp sin cloud api, n8n whatsapp gratis, automatización whatsapp n8n]
+---
+
+import Head from '@docusaurus/Head';
+import {RelatedGuides} from '@site/src/components/RelatedGuides';
+
+<Head>
+  <meta property="og:image" content="https://nicastelo.github.io/whatsmeow-node/img/guides/es/integrate-n8n.png" />
+  <meta name="twitter:image" content="https://nicastelo.github.io/whatsmeow-node/img/guides/es/integrate-n8n.png" />
+  <script type="application/ld+json">
+    {JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "HowTo",
+      "name": "How to Use whatsmeow-node with n8n",
+      "description": "Connect whatsmeow-node to n8n for WhatsApp workflow automation — send messages, receive webhooks, and build automated flows without the official Cloud API.",
+      "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/integrate-n8n.png",
+      "step": [
+        {"@type": "HowToStep", "name": "Create a whatsmeow-node REST API", "text": "Wrap whatsmeow-node in an Express server with send and webhook endpoints."},
+        {"@type": "HowToStep", "name": "Forward Messages to n8n", "text": "POST incoming WhatsApp messages to an n8n webhook trigger URL."},
+        {"@type": "HowToStep", "name": "Send Messages from n8n", "text": "Use n8n's HTTP Request node to call the whatsmeow-node REST API."},
+        {"@type": "HowToStep", "name": "Build Automated Flows", "text": "Create n8n workflows that process messages, query databases, call APIs, and reply."}
+      ]
+    })}
+  </script>
+  <script type="application/ld+json">
+    {JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "Article",
+      "headline": "How to Use whatsmeow-node with n8n",
+      "description": "Connect whatsmeow-node to n8n for WhatsApp workflow automation — send messages, receive webhooks, and build automated flows without the official Cloud API.",
+      "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/integrate-n8n.png",
+      "author": {"@type": "Organization", "name": "whatsmeow-node", "url": "https://nicastelo.github.io/whatsmeow-node/"},
+      "publisher": {"@type": "Organization", "name": "whatsmeow-node", "logo": {"@type": "ImageObject", "url": "https://nicastelo.github.io/whatsmeow-node/img/image.png"}}
+    })}
+  </script>
+</Head>
+
+![Cómo Usar whatsmeow-node con n8n](/img/guides/es/integrate-n8n.png)
+![Cómo Usar whatsmeow-node con n8n](/img/guides/es/integrate-n8n-light.png)
+
+# Cómo Usar whatsmeow-node con n8n
+
+[n8n](https://n8n.io) es una plataforma de automatización de flujos autoalojada — como Zapier, pero open source. Su nodo de WhatsApp integrado requiere la Cloud API oficial (verificación de Meta Business, precio por mensaje). Con whatsmeow-node, puedes conectar n8n a WhatsApp gratis usando un puente REST simple.
+
+## Cómo Funciona
+
+```
+n8n Workflow
+  ↕ HTTP requests / webhooks
+whatsmeow-node REST API (Express)
+  ↕
+WhatsApp
+```
+
+1. **Recibir**: whatsmeow-node recibe un mensaje de WhatsApp → lo envía por POST a un webhook de n8n
+2. **Enviar**: el flujo de n8n hace una petición HTTP → la API REST de whatsmeow-node envía el mensaje
+
+## Requisitos Previos
+
+- Una sesión vinculada de whatsmeow-node ([Cómo Vincular](pair-whatsapp))
+- n8n corriendo (autoalojado o en la nube) — `npx n8n` para inicio rápido
+- Express: `npm install express`
+
+## Paso 1: Crear la API REST de whatsmeow-node
+
+Este servidor hace dos cosas: envía mensajes vía REST y reenvía mensajes entrantes a n8n.
+
+```typescript
+import { createClient } from "@whatsmeow-node/whatsmeow-node";
+import express from "express";
+
+const client = createClient({ store: "session.db" });
+const app = express();
+app.use(express.json());
+
+// n8n webhook URL — you'll set this up in Step 3
+const N8N_WEBHOOK_URL = process.env.N8N_WEBHOOK_URL ?? "http://localhost:5678/webhook/whatsapp";
+
+// --- Sending endpoint (n8n calls this) ---
+app.post("/api/send", async (req, res) => {
+  const { phone, message, groupJid } = req.body;
+  const jid = groupJid ?? `${phone}@s.whatsapp.net`;
+
+  try {
+    const resp = await client.sendMessage(jid, { conversation: message });
+    res.json({ sent: true, id: resp.id });
+  } catch (err) {
+    res.status(500).json({ error: "Failed to send" });
+  }
+});
+
+// --- Forward incoming messages to n8n ---
+client.on("message", async ({ info, message }) => {
+  if (info.isFromMe) return;
+
+  const text =
+    (message.conversation as string) ??
+    (message.extendedTextMessage as { text?: string } | undefined)?.text;
+
+  // POST to n8n webhook
+  try {
+    await fetch(N8N_WEBHOOK_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        from: info.sender,
+        chat: info.chat,
+        pushName: info.pushName,
+        messageId: info.id,
+        text: text ?? null,
+        isGroup: info.isGroup,
+        timestamp: info.timestamp,
+        hasMedia: !!(
+          message.imageMessage ??
+          message.videoMessage ??
+          message.audioMessage ??
+          message.documentMessage
+        ),
+      }),
+    });
+  } catch (err) {
+    console.error("Failed to forward to n8n:", err);
+  }
+});
+
+async function main() {
+  const { jid } = await client.init();
+  if (!jid) {
+    console.error("Not paired!");
+    process.exit(1);
+  }
+  await client.connect();
+  app.listen(3000, () => console.log("WhatsApp API on :3000"));
+}
+
+main().catch(console.error);
+```
+
+## Paso 2: Configurar el Trigger Webhook de n8n
+
+En n8n, crea un nuevo flujo de trabajo:
+
+1. Agrega un nodo **Webhook** como trigger
+2. Configura el método como `POST`
+3. Configura el path como `whatsapp` (la URL queda `http://localhost:5678/webhook/whatsapp`)
+4. Configura la URL del webhook como `N8N_WEBHOOK_URL` en el entorno de tu API REST
+
+Ahora cada mensaje entrante de WhatsApp dispara este flujo de n8n.
+
+## Paso 3: Enviar Mensajes desde n8n
+
+Agrega un nodo **HTTP Request** a tu flujo de n8n:
+
+- **Method**: POST
+- **URL**: `http://localhost:3000/api/send`
+- **Body (JSON)**:
+```json
+{
+  "phone": "{{ $json.from.replace('@s.whatsapp.net', '') }}",
+  "message": "Thanks for your message! We'll get back to you soon."
+}
+```
+
+## Ejemplo: Flujo de Auto-Respuesta
+
+Un flujo completo de n8n que auto-responde a mensajes:
+
+```
+[Webhook Trigger] → [IF: text contains "price"] → [HTTP Request: send reply]
+                  → [IF: text contains "help"]  → [HTTP Request: send help menu]
+                  → [Default]                    → [HTTP Request: send acknowledgment]
+```
+
+## Ejemplo: Integración con CRM
+
+Reenvía mensajes de WhatsApp a un CRM y responde con el número de ticket:
+
+```
+[Webhook Trigger] → [HTTP Request: create CRM ticket]
+                  → [Set: extract ticket ID]
+                  → [HTTP Request: send "Your ticket #{{ ticketId }} has been created"]
+```
+
+## Ejemplo: Auto-Respuesta con IA
+
+Combina con OpenAI en n8n:
+
+```
+[Webhook Trigger] → [OpenAI Chat: generate reply]
+                  → [HTTP Request: send AI reply via whatsmeow-node]
+```
+
+## Agregar Más Endpoints
+
+Extiende la API REST para flujos de n8n que necesiten más funcionalidades:
+
+```typescript
+// Send media
+app.post("/api/send-media", async (req, res) => {
+  const { phone, filePath, mediaType, caption } = req.body;
+  const jid = `${phone}@s.whatsapp.net`;
+  const media = await client.uploadMedia(filePath, mediaType);
+  await client.sendRawMessage(jid, {
+    [`${mediaType}Message`]: {
+      URL: media.URL,
+      directPath: media.directPath,
+      mediaKey: media.mediaKey,
+      fileEncSHA256: media.fileEncSHA256,
+      fileSHA256: media.fileSHA256,
+      fileLength: String(media.fileLength),
+      mimetype: `${mediaType}/*`,
+      ...(caption && { caption }),
+    },
+  });
+  res.json({ sent: true });
+});
+
+// Send to group
+app.post("/api/send-group", async (req, res) => {
+  const { groupJid, message } = req.body;
+  const resp = await client.sendMessage(groupJid, { conversation: message });
+  res.json({ sent: true, id: resp.id });
+});
+
+// Mark as read
+app.post("/api/read", async (req, res) => {
+  const { messageId, chat, sender } = req.body;
+  await client.markRead([messageId], chat, sender);
+  res.json({ ok: true });
+});
+```
+
+## Errores Comunes
+
+:::warning Mantén ambos servicios corriendo
+La API REST de whatsmeow-node y n8n deben estar corriendo al mismo tiempo. Usa PM2 o Docker Compose para gestionarlos juntos.
+:::
+
+:::warning La URL del webhook debe ser accesible
+La URL del webhook de n8n debe ser accesible desde el servidor de whatsmeow-node. En Docker, usa el nombre del contenedor o alias de red, no `localhost`.
+:::
+
+:::warning Límites de tasa
+Los flujos de n8n pueden ejecutarse muy rápido. Si tu flujo envía múltiples mensajes, agrega un nodo **Wait** (1-3 segundos) entre envíos para evitar los límites de tasa de WhatsApp.
+:::
+
+<RelatedGuides slugs={["send-notifications", "integrate-whaticket", "build-a-bot", "connect-to-chatgpt"]} />

--- a/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/integrate-typebot.md
+++ b/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/integrate-typebot.md
@@ -1,0 +1,269 @@
+---
+title: "Cómo Usar whatsmeow-node con Typebot"
+sidebar_label: Integración con Typebot
+sidebar_position: 24
+description: "Conecta whatsmeow-node a Typebot para flujos de chatbot en WhatsApp — reemplaza Evolution API con un backend de WhatsApp más ligero y estable."
+keywords: [typebot whatsapp, typebot whatsmeow, typebot alternativa evolution api, typebot bot whatsapp, typebot integración whatsapp, typebot whatsapp nodejs]
+---
+
+import Head from '@docusaurus/Head';
+import {RelatedGuides} from '@site/src/components/RelatedGuides';
+
+<Head>
+  <meta property="og:image" content="https://nicastelo.github.io/whatsmeow-node/img/guides/es/integrate-typebot.png" />
+  <meta name="twitter:image" content="https://nicastelo.github.io/whatsmeow-node/img/guides/es/integrate-typebot.png" />
+  <script type="application/ld+json">
+    {JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "HowTo",
+      "name": "How to Use whatsmeow-node with Typebot",
+      "description": "Connect whatsmeow-node to Typebot for WhatsApp chatbot flows — replace Evolution API with a lighter, more stable WhatsApp backend.",
+      "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/integrate-typebot.png",
+      "step": [
+        {"@type": "HowToStep", "name": "Build a whatsmeow-node REST API", "text": "Create an Express server that bridges WhatsApp messages to Typebot via HTTP."},
+        {"@type": "HowToStep", "name": "Start a Typebot Flow", "text": "POST the first message to Typebot's API to start a conversation flow."},
+        {"@type": "HowToStep", "name": "Continue the Conversation", "text": "Send user replies to Typebot's continueChat endpoint and relay bot responses to WhatsApp."},
+        {"@type": "HowToStep", "name": "Handle Rich Messages", "text": "Parse Typebot's response blocks (text, image, input) and send appropriate WhatsApp messages."}
+      ]
+    })}
+  </script>
+  <script type="application/ld+json">
+    {JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "Article",
+      "headline": "How to Use whatsmeow-node with Typebot",
+      "description": "Connect whatsmeow-node to Typebot for WhatsApp chatbot flows — replace Evolution API with a lighter, more stable WhatsApp backend.",
+      "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/integrate-typebot.png",
+      "author": {"@type": "Organization", "name": "whatsmeow-node", "url": "https://nicastelo.github.io/whatsmeow-node/"},
+      "publisher": {"@type": "Organization", "name": "whatsmeow-node", "logo": {"@type": "ImageObject", "url": "https://nicastelo.github.io/whatsmeow-node/img/image.png"}}
+    })}
+  </script>
+</Head>
+
+![Cómo Usar whatsmeow-node con Typebot](/img/guides/es/integrate-typebot.png)
+![Cómo Usar whatsmeow-node con Typebot](/img/guides/es/integrate-typebot-light.png)
+
+# Cómo Usar whatsmeow-node con Typebot
+
+[Typebot](https://typebot.io) es un constructor de chatbots open source con un editor visual de flujos. Típicamente se conecta a WhatsApp a través de [Evolution API](https://github.com/EvolutionAPI/evolution-api) (que usa Baileys). Puedes reemplazar toda esa capa con whatsmeow-node para una conexión más ligera y estable.
+
+## Cómo Funciona
+
+```
+WhatsApp User
+  ↕
+whatsmeow-node Bridge (Express)
+  ↕ Typebot API
+Typebot Flow Engine
+```
+
+En vez de `WhatsApp → Evolution API (Baileys) → Typebot`, usas `WhatsApp → whatsmeow-node → Typebot` directamente. Menos piezas móviles, menos memoria, más estabilidad.
+
+## Requisitos Previos
+
+- Una sesión vinculada de whatsmeow-node ([Cómo Vincular](pair-whatsapp))
+- Una instancia de Typebot (autoalojada o en la nube) con un flujo publicado
+- Express: `npm install express`
+
+## Paso 1: Obtener tu ID de Typebot
+
+1. Abre tu flujo de Typebot en el editor
+2. Haz clic en **Share** y anota el ID del typebot de la URL o la configuración de embed
+3. La URL base de la API de Typebot es `https://typebot.io` (nube) o tu URL autoalojada
+
+## Paso 2: Construir el Puente
+
+El puente administra conversaciones — inicia una sesión de Typebot por usuario de WhatsApp y retransmite mensajes en ambas direcciones:
+
+```typescript
+import { createClient } from "@whatsmeow-node/whatsmeow-node";
+
+const client = createClient({ store: "session.db" });
+
+const TYPEBOT_URL = process.env.TYPEBOT_URL ?? "https://typebot.io";
+const TYPEBOT_ID = process.env.TYPEBOT_ID!;
+
+// Track active Typebot sessions per WhatsApp user
+const sessions = new Map<string, string>(); // JID → sessionId
+
+// --- Start or continue a Typebot conversation ---
+async function handleMessage(jid: string, text: string): Promise<string[]> {
+  const sessionId = sessions.get(jid);
+
+  let response;
+
+  if (!sessionId) {
+    // Start a new Typebot session
+    response = await fetch(`${TYPEBOT_URL}/api/v1/typebots/${TYPEBOT_ID}/startChat`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ message: { type: "text", text } }),
+    }).then((r) => r.json());
+
+    if (response.sessionId) {
+      sessions.set(jid, response.sessionId);
+    }
+  } else {
+    // Continue existing session
+    response = await fetch(`${TYPEBOT_URL}/api/v1/sessions/${sessionId}/continueChat`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ message: { type: "text", text } }),
+    }).then((r) => r.json());
+  }
+
+  // Extract text messages from Typebot response
+  return extractMessages(response);
+}
+
+// --- Parse Typebot response blocks into text messages ---
+function extractMessages(response: Record<string, unknown>): string[] {
+  const messages: string[] = [];
+  const msgs = (response.messages as Array<{ type: string; content?: { richText?: Array<{ children: Array<{ text?: string }> }> } }>) ?? [];
+
+  for (const msg of msgs) {
+    if (msg.type === "text" && msg.content?.richText) {
+      const text = msg.content.richText
+        .map((block) => block.children.map((c) => c.text ?? "").join(""))
+        .join("\n");
+      if (text.trim()) messages.push(text);
+    }
+  }
+
+  return messages;
+}
+
+// --- Listen for WhatsApp messages ---
+client.on("message", async ({ info, message }) => {
+  if (info.isFromMe || info.isGroup) return;
+
+  const text =
+    (message.conversation as string) ??
+    (message.extendedTextMessage as { text?: string } | undefined)?.text;
+  if (!text) return;
+
+  await client.sendChatPresence(info.chat, "composing");
+
+  try {
+    const replies = await handleMessage(info.sender, text);
+
+    for (const reply of replies) {
+      await client.sendMessage(info.chat, { conversation: reply });
+      // Small delay between multiple messages
+      if (replies.length > 1) {
+        await new Promise((r) => setTimeout(r, 1000));
+      }
+    }
+  } catch (err) {
+    console.error("Typebot error:", err);
+    await client.sendMessage(info.chat, {
+      conversation: "Sorry, I'm having trouble right now. Try again in a moment.",
+    });
+  }
+});
+
+async function main() {
+  const { jid } = await client.init();
+  if (!jid) {
+    console.error("Not paired!");
+    process.exit(1);
+  }
+  await client.connect();
+  await client.sendPresence("available");
+  console.log("Typebot bridge is online!");
+
+  process.on("SIGINT", async () => {
+    await client.sendPresence("unavailable");
+    await client.disconnect();
+    client.close();
+    process.exit(0);
+  });
+}
+
+main().catch(console.error);
+```
+
+## Manejar Tipos de Input
+
+Los flujos de Typebot pueden solicitar diferentes tipos de input. Manéjalos verificando el bloque `input`:
+
+```typescript
+function extractMessages(response: Record<string, unknown>): string[] {
+  const messages: string[] = [];
+  const msgs = (response.messages as Array<Record<string, unknown>>) ?? [];
+
+  for (const msg of msgs) {
+    if (msg.type === "text" && (msg.content as Record<string, unknown>)?.richText) {
+      const richText = (msg.content as Record<string, unknown>).richText as Array<{ children: Array<{ text?: string }> }>;
+      const text = richText
+        .map((block) => block.children.map((c) => c.text ?? "").join(""))
+        .join("\n");
+      if (text.trim()) messages.push(text);
+    }
+  }
+
+  // If the flow expects input, prompt the user
+  const input = response.input as Record<string, unknown> | undefined;
+  if (input) {
+    const inputType = input.type as string;
+    if (inputType === "choice input") {
+      const items = (input.items as Array<{ content: string }>) ?? [];
+      const options = items.map((item, i) => `${i + 1}. ${item.content}`).join("\n");
+      messages.push(options);
+    }
+  }
+
+  return messages;
+}
+```
+
+## Reiniciar Conversaciones
+
+Agrega un comando `!reset` para reiniciar el flujo de Typebot:
+
+```typescript
+client.on("message", async ({ info, message }) => {
+  if (info.isFromMe || info.isGroup) return;
+
+  const text = /* ... extract text ... */;
+  if (!text) return;
+
+  if (text.toLowerCase() === "!reset") {
+    sessions.delete(info.sender);
+    await client.sendMessage(info.chat, {
+      conversation: "Conversation reset! Send a message to start over.",
+    });
+    return;
+  }
+
+  // ... handle message as before
+});
+```
+
+## Evolution API vs whatsmeow-node
+
+Si actualmente estás usando Evolution API con Typebot, esto es lo que cambia:
+
+| | Evolution API | Puente whatsmeow-node |
+|---|---|---|
+| **Backend de WhatsApp** | Baileys | whatsmeow (Go) |
+| **Memoria** | ~50-100 MB | ~10-20 MB |
+| **Arquitectura** | Servicio separado | Integrado en el puente |
+| **Configuración** | Docker + config | `npm install` + 50 líneas |
+| **Estabilidad** | Actualizaciones de forks de Baileys | Upstream estable |
+
+## Errores Comunes
+
+:::warning Expiración de sesión
+Las sesiones de Typebot pueden expirar. Si `continueChat` devuelve un error, elimina la sesión del mapa e inicia una nueva.
+:::
+
+:::warning Límites de tasa
+Los flujos de Typebot pueden enviar múltiples mensajes en secuencia. Agrega un pequeño delay (1 segundo) entre mensajes para evitar los límites de tasa de WhatsApp.
+:::
+
+:::warning Contenido enriquecido
+Typebot soporta imágenes, videos y botones en los flujos. El puente básico de arriba solo maneja texto. Extiende `extractMessages()` para manejar bloques de multimedia y enviarlos vía `uploadMedia()` + `sendRawMessage()`.
+:::
+
+<RelatedGuides slugs={["integrate-whaticket", "integrate-n8n", "connect-to-chatgpt", "build-a-bot"]} />

--- a/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/integrate-typebot.md
+++ b/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/integrate-typebot.md
@@ -16,14 +16,14 @@ import {RelatedGuides} from '@site/src/components/RelatedGuides';
     {JSON.stringify({
       "@context": "https://schema.org",
       "@type": "HowTo",
-      "name": "How to Use whatsmeow-node with Typebot",
-      "description": "Connect whatsmeow-node to Typebot for WhatsApp chatbot flows — replace Evolution API with a lighter, more stable WhatsApp backend.",
+      "name": "Cómo Usar whatsmeow-node con Typebot",
+      "description": "Conecta whatsmeow-node a Typebot para flujos de chatbot en WhatsApp — reemplaza Evolution API con un backend de WhatsApp más ligero y estable.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/integrate-typebot.png",
       "step": [
-        {"@type": "HowToStep", "name": "Build a whatsmeow-node REST API", "text": "Create an Express server that bridges WhatsApp messages to Typebot via HTTP."},
-        {"@type": "HowToStep", "name": "Start a Typebot Flow", "text": "POST the first message to Typebot's API to start a conversation flow."},
-        {"@type": "HowToStep", "name": "Continue the Conversation", "text": "Send user replies to Typebot's continueChat endpoint and relay bot responses to WhatsApp."},
-        {"@type": "HowToStep", "name": "Handle Rich Messages", "text": "Parse Typebot's response blocks (text, image, input) and send appropriate WhatsApp messages."}
+        {"@type": "HowToStep", "name": "Construir una API REST de whatsmeow-node", "text": "Crea un servidor Express que haga de puente entre los mensajes de WhatsApp y Typebot vía HTTP."},
+        {"@type": "HowToStep", "name": "Iniciar un flujo de Typebot", "text": "Envía por POST el primer mensaje a la API de Typebot para iniciar un flujo de conversación."},
+        {"@type": "HowToStep", "name": "Continuar la conversación", "text": "Envía las respuestas del usuario al endpoint continueChat de Typebot y retransmite las respuestas del bot a WhatsApp."},
+        {"@type": "HowToStep", "name": "Manejar mensajes enriquecidos", "text": "Analiza los bloques de respuesta de Typebot (texto, imagen, input) y envía los mensajes de WhatsApp apropiados."}
       ]
     })}
   </script>
@@ -31,8 +31,8 @@ import {RelatedGuides} from '@site/src/components/RelatedGuides';
     {JSON.stringify({
       "@context": "https://schema.org",
       "@type": "Article",
-      "headline": "How to Use whatsmeow-node with Typebot",
-      "description": "Connect whatsmeow-node to Typebot for WhatsApp chatbot flows — replace Evolution API with a lighter, more stable WhatsApp backend.",
+      "headline": "Cómo Usar whatsmeow-node con Typebot",
+      "description": "Conecta whatsmeow-node a Typebot para flujos de chatbot en WhatsApp — reemplaza Evolution API con un backend de WhatsApp más ligero y estable.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/integrate-typebot.png",
       "author": {"@type": "Organization", "name": "whatsmeow-node", "url": "https://nicastelo.github.io/whatsmeow-node/"},
       "publisher": {"@type": "Organization", "name": "whatsmeow-node", "logo": {"@type": "ImageObject", "url": "https://nicastelo.github.io/whatsmeow-node/img/image.png"}}

--- a/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/integrate-whaticket.md
+++ b/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/integrate-whaticket.md
@@ -1,0 +1,353 @@
+---
+title: "Cómo Usar whatsmeow-node con Whaticket"
+sidebar_label: Integración con Whaticket
+sidebar_position: 21
+description: "Reemplaza whatsapp-web.js con whatsmeow-node en Whaticket — elimina Puppeteer, reduce el consumo de memoria y obtén una conexión de WhatsApp más estable para tu helpdesk."
+keywords: [whaticket whatsmeow, whaticket sin baileys, whaticket alternativa whatsapp-web.js, whaticket whatsmeow-node, whaticket estable, whaticket sin puppeteer]
+---
+
+import Head from '@docusaurus/Head';
+import {RelatedGuides} from '@site/src/components/RelatedGuides';
+
+<Head>
+  <meta property="og:image" content="https://nicastelo.github.io/whatsmeow-node/img/guides/es/integrate-whaticket.png" />
+  <meta name="twitter:image" content="https://nicastelo.github.io/whatsmeow-node/img/guides/es/integrate-whaticket.png" />
+  <script type="application/ld+json">
+    {JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "HowTo",
+      "name": "How to Use whatsmeow-node with Whaticket",
+      "description": "Replace whatsapp-web.js with whatsmeow-node in Whaticket — drop Puppeteer, cut memory usage, and get a more stable WhatsApp connection for your helpdesk.",
+      "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/integrate-whaticket.png",
+      "step": [
+        {"@type": "HowToStep", "name": "Install whatsmeow-node", "text": "Add whatsmeow-node to the Whaticket backend and remove whatsapp-web.js and Puppeteer."},
+        {"@type": "HowToStep", "name": "Create the WhatsApp Service", "text": "Build a service module that wraps whatsmeow-node and exposes send/receive methods for Whaticket."},
+        {"@type": "HowToStep", "name": "Handle QR Pairing", "text": "Emit QR codes to the Whaticket frontend via the existing WebSocket connection."},
+        {"@type": "HowToStep", "name": "Route Messages to Tickets", "text": "Listen for incoming messages and create or update tickets in the database."},
+        {"@type": "HowToStep", "name": "Send Replies", "text": "When agents reply in the Whaticket UI, send the message via whatsmeow-node."}
+      ]
+    })}
+  </script>
+  <script type="application/ld+json">
+    {JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "Article",
+      "headline": "How to Use whatsmeow-node with Whaticket",
+      "description": "Replace whatsapp-web.js with whatsmeow-node in Whaticket — drop Puppeteer, cut memory usage, and get a more stable WhatsApp connection for your helpdesk.",
+      "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/integrate-whaticket.png",
+      "author": {"@type": "Organization", "name": "whatsmeow-node", "url": "https://nicastelo.github.io/whatsmeow-node/"},
+      "publisher": {"@type": "Organization", "name": "whatsmeow-node", "logo": {"@type": "ImageObject", "url": "https://nicastelo.github.io/whatsmeow-node/img/image.png"}}
+    })}
+  </script>
+</Head>
+
+![Cómo Usar whatsmeow-node con Whaticket](/img/guides/es/integrate-whaticket.png)
+![Cómo Usar whatsmeow-node con Whaticket](/img/guides/es/integrate-whaticket-light.png)
+
+# Cómo Usar whatsmeow-node con Whaticket
+
+[Whaticket](https://github.com/canove/whaticket-community) es un helpdesk de WhatsApp open source construido con Express + React. Usa whatsapp-web.js (basado en Puppeteer) para la conectividad de WhatsApp, lo cual es pesado (~500 MB de RAM), se rompe con actualizaciones de WhatsApp Web y requiere un navegador headless.
+
+whatsmeow-node es un reemplazo directo — mismo patrón basado en eventos, mismo runtime de Node.js, pero 10-20 MB de RAM en vez de 500 MB, sin navegador y un protocolo más estable.
+
+## ¿Por Qué Reemplazar whatsapp-web.js en Whaticket?
+
+| | whatsapp-web.js (actual) | whatsmeow-node |
+|---|---|---|
+| **Memoria por sesión** | 200-500 MB (Chromium) | ~10-20 MB |
+| **Arranque** | 5-15s (lanzamiento del navegador) | Menos de 1 segundo |
+| **Estabilidad** | Se rompe con actualizaciones de WhatsApp Web | Upstream estable (whatsmeow) |
+| **Imagen Docker** | ~1 GB+ (necesita Chrome) | ~50 MB |
+| **Protocolo** | Automatización del cliente web | Multi-dispositivo nativo |
+
+Para despliegues de Whaticket multi-sesión, esto significa ejecutar 10+ conexiones de WhatsApp en un solo VPS de 1 GB en lugar de necesitar 4+ GB.
+
+## Visión General de la Arquitectura
+
+La integración de WhatsApp de Whaticket está en el backend Express:
+
+```
+Whaticket Frontend (React)
+  ↕ WebSocket + REST
+Whaticket Backend (Express)
+  ↕ WhatsApp Service
+whatsapp-web.js → Replace with whatsmeow-node
+  ↕
+WhatsApp
+```
+
+El cambio ocurre en la capa del servicio de WhatsApp — todo lo de arriba (tickets, contactos, UI) se mantiene igual.
+
+## Paso 1: Instalar whatsmeow-node
+
+En el directorio del backend de Whaticket:
+
+```bash
+# Remove whatsapp-web.js and Puppeteer
+npm uninstall whatsapp-web.js puppeteer
+
+# Install whatsmeow-node
+npm install @whatsmeow-node/whatsmeow-node
+```
+
+## Paso 2: Crear el Servicio de WhatsApp
+
+Reemplaza el servicio de whatsapp-web.js con un wrapper de whatsmeow-node:
+
+```typescript
+// src/services/WhatsappService.ts
+import { createClient, WhatsmeowClient } from "@whatsmeow-node/whatsmeow-node";
+import { EventEmitter } from "events";
+
+export class WhatsappService extends EventEmitter {
+  private client: WhatsmeowClient;
+  private jid: string | null = null;
+
+  constructor(sessionId: string, storePath: string) {
+    super();
+    this.client = createClient({ store: `${storePath}/${sessionId}.db` });
+    this.setupListeners();
+  }
+
+  private setupListeners() {
+    this.client.on("qr", ({ code }) => {
+      this.emit("qr", code);
+    });
+
+    this.client.on("connected", ({ jid }) => {
+      this.jid = jid;
+      this.emit("ready", jid);
+    });
+
+    this.client.on("message", ({ info, message }) => {
+      if (info.isFromMe) return;
+      this.emit("message", { info, message });
+    });
+
+    this.client.on("disconnected", () => {
+      this.emit("disconnected");
+    });
+
+    this.client.on("logged_out", ({ reason }) => {
+      this.emit("logged_out", reason);
+    });
+  }
+
+  async start() {
+    const { jid } = await this.client.init();
+    if (jid) {
+      this.jid = jid;
+      await this.client.connect();
+      return { paired: true, jid };
+    }
+    // Not paired — start QR flow
+    await this.client.getQRChannel();
+    await this.client.connect();
+    return { paired: false };
+  }
+
+  async sendText(to: string, text: string) {
+    return this.client.sendMessage(to, { conversation: text });
+  }
+
+  async sendMedia(to: string, filePath: string, mediaType: "image" | "video" | "audio" | "document", caption?: string) {
+    const media = await this.client.uploadMedia(filePath, mediaType);
+    const typeKey = `${mediaType}Message`;
+    return this.client.sendRawMessage(to, {
+      [typeKey]: {
+        URL: media.URL,
+        directPath: media.directPath,
+        mediaKey: media.mediaKey,
+        fileEncSHA256: media.fileEncSHA256,
+        fileSHA256: media.fileSHA256,
+        fileLength: String(media.fileLength),
+        mimetype: this.getMimeType(filePath, mediaType),
+        ...(caption && { caption }),
+      },
+    });
+  }
+
+  async markRead(messageId: string, chat: string, sender?: string) {
+    await this.client.markRead([messageId], chat, sender);
+  }
+
+  async disconnect() {
+    await this.client.sendPresence("unavailable");
+    await this.client.disconnect();
+    this.client.close();
+  }
+
+  getJid() {
+    return this.jid;
+  }
+
+  private getMimeType(filePath: string, mediaType: string): string {
+    const ext = filePath.split(".").pop()?.toLowerCase();
+    const mimes: Record<string, string> = {
+      jpg: "image/jpeg", jpeg: "image/jpeg", png: "image/png", gif: "image/gif",
+      mp4: "video/mp4", mp3: "audio/mpeg", ogg: "audio/ogg",
+      pdf: "application/pdf", doc: "application/msword",
+    };
+    return mimes[ext ?? ""] ?? `${mediaType}/*`;
+  }
+}
+```
+
+## Paso 3: Manejar el Emparejamiento QR vía WebSocket
+
+Whaticket muestra los QR codes en la UI de administración. Reenvíalos a través de la conexión WebSocket existente:
+
+```typescript
+// In your session initialization handler
+import { WhatsappService } from "./services/WhatsappService";
+
+const sessions = new Map<string, WhatsappService>();
+
+function initSession(sessionId: string, io: SocketIO.Server) {
+  const service = new WhatsappService(sessionId, "./sessions");
+
+  service.on("qr", (code) => {
+    // Send QR to the admin UI via WebSocket
+    io.to(sessionId).emit("whatsapp:qr", { code });
+  });
+
+  service.on("ready", (jid) => {
+    io.to(sessionId).emit("whatsapp:ready", { jid });
+    // Update session status in database
+    updateSessionStatus(sessionId, "connected", jid);
+  });
+
+  service.on("message", async ({ info, message }) => {
+    // Route to ticket system
+    await handleIncomingMessage(sessionId, info, message);
+  });
+
+  service.on("disconnected", () => {
+    io.to(sessionId).emit("whatsapp:disconnected");
+    updateSessionStatus(sessionId, "disconnected");
+  });
+
+  service.start();
+  sessions.set(sessionId, service);
+}
+```
+
+## Paso 4: Enrutar Mensajes a Tickets
+
+Convierte los mensajes entrantes de WhatsApp en tickets de Whaticket:
+
+```typescript
+async function handleIncomingMessage(
+  sessionId: string,
+  info: { chat: string; sender: string; pushName: string; id: string; isGroup: boolean },
+  message: Record<string, unknown>,
+) {
+  const contactJid = info.isGroup ? info.sender : info.chat;
+
+  // Find or create contact
+  const contact = await findOrCreateContact(contactJid, info.pushName);
+
+  // Find open ticket or create new one
+  const ticket = await findOrCreateTicket(contact.id, sessionId);
+
+  // Extract message text
+  const text =
+    (message.conversation as string) ??
+    (message.extendedTextMessage as { text?: string } | undefined)?.text ??
+    "[media]";
+
+  // Save message to ticket
+  await createMessage({
+    ticketId: ticket.id,
+    contactId: contact.id,
+    body: text,
+    fromMe: false,
+    messageId: info.id,
+  });
+
+  // Notify agents via WebSocket
+  io.to(`ticket:${ticket.id}`).emit("ticket:message", {
+    ticketId: ticket.id,
+    message: text,
+    contact: contact.name,
+  });
+}
+```
+
+## Paso 5: Enviar Respuestas
+
+Cuando un agente responde desde la UI de Whaticket:
+
+```typescript
+// In your message sending endpoint
+app.post("/api/messages/:ticketId", async (req, res) => {
+  const { ticketId } = req.params;
+  const { body, mediaPath, mediaType } = req.body;
+
+  const ticket = await getTicket(ticketId);
+  const session = sessions.get(ticket.sessionId);
+  if (!session) return res.status(400).json({ error: "Session not connected" });
+
+  let response;
+  if (mediaPath) {
+    response = await session.sendMedia(ticket.contactJid, mediaPath, mediaType, body);
+  } else {
+    response = await session.sendText(ticket.contactJid, body);
+  }
+
+  // Save outgoing message
+  await createMessage({
+    ticketId: ticket.id,
+    body,
+    fromMe: true,
+    messageId: response.id,
+  });
+
+  res.json({ sent: true, id: response.id });
+});
+```
+
+## Gestión Multi-Sesión
+
+Whaticket soporta múltiples números de WhatsApp. whatsmeow-node lo maneja con instancias de cliente separadas:
+
+```typescript
+// Each session gets its own client + database
+const session1 = new WhatsappService("support", "./sessions");   // sessions/support.db
+const session2 = new WhatsappService("sales", "./sessions");     // sessions/sales.db
+const session3 = new WhatsappService("marketing", "./sessions"); // sessions/marketing.db
+
+// Total memory: ~30-60 MB for 3 sessions
+// With whatsapp-web.js: ~1.5 GB for 3 sessions
+```
+
+## Limpieza de Docker
+
+Elimina Chromium de tu Dockerfile:
+
+```dockerfile
+# Before (whatsapp-web.js)
+FROM node:20
+RUN apt-get update && apt-get install -y chromium
+# Image size: ~1.2 GB
+
+# After (whatsmeow-node)
+FROM node:20-slim
+# Image size: ~200 MB
+```
+
+## Errores Comunes
+
+:::warning Migración de sesión
+Las sesiones de whatsapp-web.js no se pueden migrar. Cada número de WhatsApp necesita vincularse de nuevo escaneando un QR code. El historial de chat y los contactos no se ven afectados.
+:::
+
+:::warning Cambio de formato de JID
+whatsapp-web.js usa `number@c.us` para contactos. whatsmeow-node usa `number@s.whatsapp.net`. Actualiza cualquier JID almacenado en tu base de datos.
+:::
+
+:::warning Manejo de multimedia
+whatsapp-web.js te da `msg.downloadMedia()` que devuelve base64. `downloadAny()` de whatsmeow-node guarda en un archivo temporal. Ajusta tu pipeline de multimedia acorde.
+:::
+
+<RelatedGuides slugs={["migrate-from-whatsapp-web-js", "send-notifications", "whatsmeow-in-node", "automate-group-messages"]} />

--- a/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/integrate-whaticket.md
+++ b/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/integrate-whaticket.md
@@ -16,15 +16,15 @@ import {RelatedGuides} from '@site/src/components/RelatedGuides';
     {JSON.stringify({
       "@context": "https://schema.org",
       "@type": "HowTo",
-      "name": "How to Use whatsmeow-node with Whaticket",
-      "description": "Replace whatsapp-web.js with whatsmeow-node in Whaticket — drop Puppeteer, cut memory usage, and get a more stable WhatsApp connection for your helpdesk.",
+      "name": "Cómo Usar whatsmeow-node con Whaticket",
+      "description": "Reemplaza whatsapp-web.js con whatsmeow-node en Whaticket — elimina Puppeteer, reduce el consumo de memoria y obtén una conexión de WhatsApp más estable para tu helpdesk.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/integrate-whaticket.png",
       "step": [
-        {"@type": "HowToStep", "name": "Install whatsmeow-node", "text": "Add whatsmeow-node to the Whaticket backend and remove whatsapp-web.js and Puppeteer."},
-        {"@type": "HowToStep", "name": "Create the WhatsApp Service", "text": "Build a service module that wraps whatsmeow-node and exposes send/receive methods for Whaticket."},
-        {"@type": "HowToStep", "name": "Handle QR Pairing", "text": "Emit QR codes to the Whaticket frontend via the existing WebSocket connection."},
-        {"@type": "HowToStep", "name": "Route Messages to Tickets", "text": "Listen for incoming messages and create or update tickets in the database."},
-        {"@type": "HowToStep", "name": "Send Replies", "text": "When agents reply in the Whaticket UI, send the message via whatsmeow-node."}
+        {"@type": "HowToStep", "name": "Instalar whatsmeow-node", "text": "Agrega whatsmeow-node al backend de Whaticket y elimina whatsapp-web.js y Puppeteer."},
+        {"@type": "HowToStep", "name": "Crear el servicio de WhatsApp", "text": "Construye un módulo de servicio que envuelva whatsmeow-node y exponga métodos de envío/recepción para Whaticket."},
+        {"@type": "HowToStep", "name": "Manejar el emparejamiento QR", "text": "Emite los QR codes al frontend de Whaticket a través de la conexión WebSocket existente."},
+        {"@type": "HowToStep", "name": "Enrutar mensajes a tickets", "text": "Escucha los mensajes entrantes y crea o actualiza tickets en la base de datos."},
+        {"@type": "HowToStep", "name": "Enviar respuestas", "text": "Cuando los agentes responden en la UI de Whaticket, envía el mensaje vía whatsmeow-node."}
       ]
     })}
   </script>
@@ -32,8 +32,8 @@ import {RelatedGuides} from '@site/src/components/RelatedGuides';
     {JSON.stringify({
       "@context": "https://schema.org",
       "@type": "Article",
-      "headline": "How to Use whatsmeow-node with Whaticket",
-      "description": "Replace whatsapp-web.js with whatsmeow-node in Whaticket — drop Puppeteer, cut memory usage, and get a more stable WhatsApp connection for your helpdesk.",
+      "headline": "Cómo Usar whatsmeow-node con Whaticket",
+      "description": "Reemplaza whatsapp-web.js con whatsmeow-node en Whaticket — elimina Puppeteer, reduce el consumo de memoria y obtén una conexión de WhatsApp más estable para tu helpdesk.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/integrate-whaticket.png",
       "author": {"@type": "Organization", "name": "whatsmeow-node", "url": "https://nicastelo.github.io/whatsmeow-node/"},
       "publisher": {"@type": "Organization", "name": "whatsmeow-node", "logo": {"@type": "ImageObject", "url": "https://nicastelo.github.io/whatsmeow-node/img/image.png"}}

--- a/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/migrate-from-baileys.md
+++ b/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/migrate-from-baileys.md
@@ -1,0 +1,281 @@
+---
+title: "Cómo Reemplazar Baileys con whatsmeow-node"
+sidebar_label: Migrar desde Baileys
+sidebar_position: 10
+description: "Migra tu bot de WhatsApp de Baileys a whatsmeow-node — comparación de código lado a lado, mapeo de API y guía de migración paso a paso."
+keywords: [alternativa a baileys, reemplazar baileys, baileys a whatsmeow, migración baileys, migración bot whatsapp nodejs, baileys vs whatsmeow]
+---
+
+import Head from '@docusaurus/Head';
+import {RelatedGuides} from '@site/src/components/RelatedGuides';
+
+<Head>
+  <meta property="og:image" content="https://nicastelo.github.io/whatsmeow-node/img/guides/es/migrate-from-baileys.png" />
+  <meta name="twitter:image" content="https://nicastelo.github.io/whatsmeow-node/img/guides/es/migrate-from-baileys.png" />
+  <script type="application/ld+json">
+    {JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "HowTo",
+      "name": "How to Replace Baileys with whatsmeow-node",
+      "description": "Migrate your WhatsApp bot from Baileys to whatsmeow-node — side-by-side code comparison, API mapping, and step-by-step migration guide.",
+      "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/migrate-from-baileys.png",
+      "step": [
+        {"@type": "HowToStep", "name": "Install whatsmeow-node", "text": "Replace @whiskeysockets/baileys with @whatsmeow-node/whatsmeow-node in your dependencies."},
+        {"@type": "HowToStep", "name": "Update Client Initialization", "text": "Replace makeWASocket with createClient. Switch from useMultiFileAuthState to a store path."},
+        {"@type": "HowToStep", "name": "Update Event Listeners", "text": "Replace ev.on('messages.upsert') with client.on('message'). Update event shapes to match whatsmeow-node."},
+        {"@type": "HowToStep", "name": "Update Message Sending", "text": "Replace sendMessage with the whatsmeow-node equivalent. Content shape is similar but key names differ."},
+        {"@type": "HowToStep", "name": "Update Group Operations", "text": "Replace groupCreate, groupMetadata, etc. with the whatsmeow-node equivalents."}
+      ]
+    })}
+  </script>
+  <script type="application/ld+json">
+    {JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "Article",
+      "headline": "How to Replace Baileys with whatsmeow-node",
+      "description": "Migrate your WhatsApp bot from Baileys to whatsmeow-node — side-by-side code comparison, API mapping, and step-by-step migration guide.",
+      "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/migrate-from-baileys.png",
+      "author": {"@type": "Organization", "name": "whatsmeow-node", "url": "https://nicastelo.github.io/whatsmeow-node/"},
+      "publisher": {"@type": "Organization", "name": "whatsmeow-node", "logo": {"@type": "ImageObject", "url": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/migrate-from-baileys.png"}}
+    })}
+  </script>
+</Head>
+
+![Cómo Reemplazar Baileys con whatsmeow-node](/img/guides/es/migrate-from-baileys.png)
+![Cómo Reemplazar Baileys con whatsmeow-node](/img/guides/es/migrate-from-baileys-light.png)
+
+# Cómo Reemplazar Baileys con whatsmeow-node
+
+Si estás usando [Baileys](https://github.com/WhiskeySockets/Baileys) y te topas con problemas de mantenimiento, inestabilidad de forks, o quieres un upstream más confiable, whatsmeow-node es una alternativa directa con una superficie de API similar. Esta guía mapea los conceptos clave y te muestra cómo migrar.
+
+## ¿Por Qué Migrar?
+
+- **Upstream estable** — whatsmeow es mantenido por el equipo de Mautrix y usado en producción por miles de puentes Matrix 24/7. Cuando WhatsApp cambia su protocolo, los arreglos llegan rápido.
+- **Sin ruleta de forks** — Baileys ha pasado por múltiples forks (adiwajshing → WhiskeySockets → otros). whatsmeow-node envuelve una sola biblioteca Go estable.
+- **Menor consumo de memoria** — ~10-20 MB vs ~50 MB típico de Baileys.
+- **API tipada** — Más de 100 métodos async tipados con diseño TypeScript-first.
+
+Consulta la [Comparación con Alternativas](/docs/comparison) para más detalles.
+
+## Paso 1: Instalar
+
+```bash
+# Remove Baileys
+npm uninstall @whiskeysockets/baileys
+
+# Install whatsmeow-node
+npm install @whatsmeow-node/whatsmeow-node
+```
+
+## Paso 2: Actualizar la Inicialización del Cliente
+
+### Baileys
+
+```typescript
+import makeWASocket, { useMultiFileAuthState } from "@whiskeysockets/baileys";
+
+const { state, saveCreds } = await useMultiFileAuthState("auth_info");
+const sock = makeWASocket({ auth: state });
+sock.ev.on("creds.update", saveCreds);
+```
+
+### whatsmeow-node
+
+```typescript
+import { createClient } from "@whatsmeow-node/whatsmeow-node";
+
+const client = createClient({ store: "session.db" });
+const { jid } = await client.init();
+await client.connect();
+```
+
+La persistencia de sesión es automática — no se necesita callback `saveCreds`. La opción `store` acepta una ruta de archivo (SQLite) o una cadena de conexión de PostgreSQL.
+
+:::info
+Necesitarás vincular de nuevo (escanear QR code) después del cambio. El estado de autenticación de Baileys no es compatible con las sesiones de whatsmeow.
+:::
+
+## Paso 3: Actualizar los Listeners de Eventos
+
+### Mensajes
+
+**Baileys:**
+```typescript
+sock.ev.on("messages.upsert", ({ messages }) => {
+  for (const msg of messages) {
+    if (msg.key.fromMe) continue;
+    const text = msg.message?.conversation
+      ?? msg.message?.extendedTextMessage?.text;
+    console.log(`${msg.pushName}: ${text}`);
+  }
+});
+```
+
+**whatsmeow-node:**
+```typescript
+client.on("message", ({ info, message }) => {
+  if (info.isFromMe) return;
+  const text =
+    (message.conversation as string) ??
+    (message.extendedTextMessage as { text?: string } | undefined)?.text;
+  console.log(`${info.pushName}: ${text}`);
+});
+```
+
+Diferencias clave:
+- Un solo mensaje por evento (no en lote)
+- Los metadatos del mensaje están en `info`, el contenido protobuf en `message`
+- `info.isFromMe` reemplaza a `msg.key.fromMe`
+- `info.chat` reemplaza a `msg.key.remoteJid`
+- `info.sender` reemplaza a `msg.key.participant` (en grupos)
+
+### Conexión
+
+**Baileys:**
+```typescript
+sock.ev.on("connection.update", ({ connection, lastDisconnect }) => {
+  if (connection === "open") console.log("Connected!");
+  if (connection === "close") { /* handle reconnection */ }
+});
+```
+
+**whatsmeow-node:**
+```typescript
+client.on("connected", ({ jid }) => console.log(`Connected as ${jid}`));
+client.on("disconnected", () => console.log("Disconnected"));
+client.on("logged_out", ({ reason }) => console.error(`Logged out: ${reason}`));
+```
+
+No necesitas lógica de reconexión manual — whatsmeow la maneja automáticamente.
+
+## Paso 4: Actualizar el Envío de Mensajes
+
+### Mensaje de texto
+
+**Baileys:**
+```typescript
+await sock.sendMessage(jid, { text: "Hello!" });
+```
+
+**whatsmeow-node:**
+```typescript
+await client.sendMessage(jid, { conversation: "Hello!" });
+```
+
+### Respuesta con cita
+
+**Baileys:**
+```typescript
+await sock.sendMessage(jid, { text: "Reply!" }, { quoted: msg });
+```
+
+**whatsmeow-node:**
+```typescript
+await client.sendRawMessage(jid, {
+  extendedTextMessage: {
+    text: "Reply!",
+    contextInfo: {
+      stanzaId: info.id,
+      participant: info.sender,
+      quotedMessage: { conversation: originalText },
+    },
+  },
+});
+```
+
+### Multimedia
+
+**Baileys:**
+```typescript
+await sock.sendMessage(jid, {
+  image: { url: "/path/to/photo.jpg" },
+  caption: "Check this out",
+});
+```
+
+**whatsmeow-node:**
+```typescript
+const media = await client.uploadMedia("/path/to/photo.jpg", "image");
+await client.sendRawMessage(jid, {
+  imageMessage: {
+    URL: media.URL,
+    directPath: media.directPath,
+    mediaKey: media.mediaKey,
+    fileEncSHA256: media.fileEncSHA256,
+    fileSHA256: media.fileSHA256,
+    fileLength: String(media.fileLength),
+    mimetype: "image/jpeg",
+    caption: "Check this out",
+  },
+});
+```
+
+La subida y el envío de multimedia son pasos separados en whatsmeow-node. Esto te da más control (por ejemplo, subir una vez y enviar a múltiples chats).
+
+### Reacciones
+
+**Baileys:**
+```typescript
+await sock.sendMessage(jid, { react: { text: "👍", key: msg.key } });
+```
+
+**whatsmeow-node:**
+```typescript
+await client.sendReaction(jid, senderJid, messageId, "👍");
+```
+
+## Paso 5: Actualizar Operaciones de Grupo
+
+| Baileys | whatsmeow-node |
+|---------|----------------|
+| `sock.groupCreate(name, members)` | `client.createGroup(name, members)` |
+| `sock.groupMetadata(jid)` | `client.getGroupInfo(jid)` |
+| `sock.groupFetchAllParticipating()` | `client.getJoinedGroups()` |
+| `sock.groupUpdateSubject(jid, name)` | `client.setGroupName(jid, name)` |
+| `sock.groupUpdateDescription(jid, desc)` | `client.setGroupDescription(jid, desc)` |
+| `sock.groupSettingUpdate(jid, "announcement")` | `client.setGroupAnnounce(jid, true)` |
+| `sock.groupParticipantsUpdate(jid, [jid], "add")` | `client.updateGroupParticipants(jid, [jid], "add")` |
+| `sock.groupInviteCode(jid)` | `client.getGroupInviteLink(jid)` |
+| `sock.groupLeave(jid)` | `client.leaveGroup(jid)` |
+
+## Referencia Rápida de la API
+
+| Baileys | whatsmeow-node |
+|---------|----------------|
+| `makeWASocket()` | `createClient()` |
+| `sock.sendMessage(jid, content)` | `client.sendMessage(jid, content)` |
+| `sock.readMessages([key])` | `client.markRead([id], chat, sender)` |
+| `sock.sendPresenceUpdate("available")` | `client.sendPresence("available")` |
+| `sock.presenceSubscribe(jid)` | `client.subscribePresence(jid)` |
+| `sock.profilePictureUrl(jid)` | `client.getProfilePicture(jid)` |
+| `sock.updateBlockStatus(jid, "block")` | `client.updateBlocklist(jid, "block")` |
+| `sock.logout()` | `client.logout()` |
+
+## Lista de Verificación de Migración
+
+- [ ] Instalar `@whatsmeow-node/whatsmeow-node`, eliminar `@whiskeysockets/baileys`
+- [ ] Reemplazar `makeWASocket` → `createClient`
+- [ ] Eliminar `useMultiFileAuthState` — la sesión se maneja automáticamente
+- [ ] Actualizar listeners de eventos (`ev.on` → `client.on`, nombres de eventos diferentes)
+- [ ] Actualizar llamadas a `sendMessage` (`text` → `conversation`)
+- [ ] Actualizar envío de multimedia (pasos separados de upload + envío)
+- [ ] Actualizar operaciones de grupo (los nombres de métodos difieren ligeramente)
+- [ ] Eliminar lógica de reconexión manual — whatsmeow se reconecta automáticamente
+- [ ] Vincular de nuevo vía QR code (se requiere nueva sesión)
+- [ ] Probar todos los tipos de mensaje de extremo a extremo
+
+## Errores Comunes
+
+:::warning Se requiere nueva sesión
+El estado de autenticación de Baileys no se puede migrar. Debes vincular una nueva sesión escaneando el QR code. Tu historial de chat y contactos de WhatsApp no se ven afectados — solo el enlace del dispositivo es nuevo.
+:::
+
+:::warning `text` vs `conversation`
+Baileys usa `{ text: "..." }` para mensajes. whatsmeow-node usa `{ conversation: "..." }` — coincidiendo con el nombre del campo protobuf de WhatsApp.
+:::
+
+:::warning Casing de campos proto
+Los campos de respuesta de upload usan el casing exacto de protobuf: `URL`, `fileSHA256`, `fileEncSHA256` — **no** camelCase. Usar el casing incorrecto falla silenciosamente.
+:::
+
+<RelatedGuides slugs={["whatsmeow-in-node", "build-a-bot", "migrate-from-whatsapp-web-js"]} />

--- a/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/migrate-from-baileys.md
+++ b/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/migrate-from-baileys.md
@@ -16,15 +16,15 @@ import {RelatedGuides} from '@site/src/components/RelatedGuides';
     {JSON.stringify({
       "@context": "https://schema.org",
       "@type": "HowTo",
-      "name": "How to Replace Baileys with whatsmeow-node",
-      "description": "Migrate your WhatsApp bot from Baileys to whatsmeow-node — side-by-side code comparison, API mapping, and step-by-step migration guide.",
+      "name": "Cómo Reemplazar Baileys con whatsmeow-node",
+      "description": "Migra tu bot de WhatsApp de Baileys a whatsmeow-node — comparación de código lado a lado, mapeo de API y guía de migración paso a paso.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/migrate-from-baileys.png",
       "step": [
-        {"@type": "HowToStep", "name": "Install whatsmeow-node", "text": "Replace @whiskeysockets/baileys with @whatsmeow-node/whatsmeow-node in your dependencies."},
-        {"@type": "HowToStep", "name": "Update Client Initialization", "text": "Replace makeWASocket with createClient. Switch from useMultiFileAuthState to a store path."},
-        {"@type": "HowToStep", "name": "Update Event Listeners", "text": "Replace ev.on('messages.upsert') with client.on('message'). Update event shapes to match whatsmeow-node."},
-        {"@type": "HowToStep", "name": "Update Message Sending", "text": "Replace sendMessage with the whatsmeow-node equivalent. Content shape is similar but key names differ."},
-        {"@type": "HowToStep", "name": "Update Group Operations", "text": "Replace groupCreate, groupMetadata, etc. with the whatsmeow-node equivalents."}
+        {"@type": "HowToStep", "name": "Instalar whatsmeow-node", "text": "Reemplaza @whiskeysockets/baileys con @whatsmeow-node/whatsmeow-node en tus dependencias."},
+        {"@type": "HowToStep", "name": "Actualizar la inicialización del cliente", "text": "Reemplaza makeWASocket con createClient. Cambia de useMultiFileAuthState a una ruta de almacén."},
+        {"@type": "HowToStep", "name": "Actualizar los listeners de eventos", "text": "Reemplaza ev.on('messages.upsert') con client.on('message'). Actualiza las formas de eventos para que coincidan con whatsmeow-node."},
+        {"@type": "HowToStep", "name": "Actualizar el envío de mensajes", "text": "Reemplaza sendMessage con el equivalente de whatsmeow-node. La forma del contenido es similar pero los nombres de las claves difieren."},
+        {"@type": "HowToStep", "name": "Actualizar operaciones de grupo", "text": "Reemplaza groupCreate, groupMetadata, etc. con los equivalentes de whatsmeow-node."}
       ]
     })}
   </script>
@@ -32,8 +32,8 @@ import {RelatedGuides} from '@site/src/components/RelatedGuides';
     {JSON.stringify({
       "@context": "https://schema.org",
       "@type": "Article",
-      "headline": "How to Replace Baileys with whatsmeow-node",
-      "description": "Migrate your WhatsApp bot from Baileys to whatsmeow-node — side-by-side code comparison, API mapping, and step-by-step migration guide.",
+      "headline": "Cómo Reemplazar Baileys con whatsmeow-node",
+      "description": "Migra tu bot de WhatsApp de Baileys a whatsmeow-node — comparación de código lado a lado, mapeo de API y guía de migración paso a paso.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/migrate-from-baileys.png",
       "author": {"@type": "Organization", "name": "whatsmeow-node", "url": "https://nicastelo.github.io/whatsmeow-node/"},
       "publisher": {"@type": "Organization", "name": "whatsmeow-node", "logo": {"@type": "ImageObject", "url": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/migrate-from-baileys.png"}}

--- a/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/migrate-from-whatsapp-web-js.md
+++ b/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/migrate-from-whatsapp-web-js.md
@@ -16,15 +16,15 @@ import {RelatedGuides} from '@site/src/components/RelatedGuides';
     {JSON.stringify({
       "@context": "https://schema.org",
       "@type": "HowTo",
-      "name": "How to Replace whatsapp-web.js with whatsmeow-node",
-      "description": "Migrate from whatsapp-web.js to whatsmeow-node — drop Puppeteer, cut memory from 500 MB to 20 MB, and get a typed async API.",
+      "name": "Cómo Reemplazar whatsapp-web.js con whatsmeow-node",
+      "description": "Migra de whatsapp-web.js a whatsmeow-node — elimina Puppeteer, reduce la memoria de 500 MB a 20 MB y obtén una API async tipada.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/migrate-from-whatsapp-web-js.png",
       "step": [
-        {"@type": "HowToStep", "name": "Install whatsmeow-node", "text": "Replace whatsapp-web.js and puppeteer with @whatsmeow-node/whatsmeow-node."},
-        {"@type": "HowToStep", "name": "Update Client Initialization", "text": "Replace new Client() with createClient(). No LocalAuth or Puppeteer configuration needed."},
-        {"@type": "HowToStep", "name": "Update Event Listeners", "text": "Replace client.on('message') callback shapes and update message property access patterns."},
-        {"@type": "HowToStep", "name": "Update Message Sending", "text": "Replace client.sendMessage() with the whatsmeow-node sendMessage or sendRawMessage methods."},
-        {"@type": "HowToStep", "name": "Remove Browser Dependencies", "text": "Remove Puppeteer, Chromium, and any browser-related configuration from your project."}
+        {"@type": "HowToStep", "name": "Instalar whatsmeow-node", "text": "Reemplaza whatsapp-web.js y puppeteer con @whatsmeow-node/whatsmeow-node."},
+        {"@type": "HowToStep", "name": "Actualizar la inicialización del cliente", "text": "Reemplaza new Client() con createClient(). No se necesita configuración de LocalAuth ni Puppeteer."},
+        {"@type": "HowToStep", "name": "Actualizar los listeners de eventos", "text": "Reemplaza las formas de callback de client.on('message') y actualiza los patrones de acceso a propiedades de mensajes."},
+        {"@type": "HowToStep", "name": "Actualizar el envío de mensajes", "text": "Reemplaza client.sendMessage() con los métodos sendMessage o sendRawMessage de whatsmeow-node."},
+        {"@type": "HowToStep", "name": "Eliminar dependencias del navegador", "text": "Elimina Puppeteer, Chromium y cualquier configuración relacionada con el navegador de tu proyecto."}
       ]
     })}
   </script>
@@ -32,8 +32,8 @@ import {RelatedGuides} from '@site/src/components/RelatedGuides';
     {JSON.stringify({
       "@context": "https://schema.org",
       "@type": "Article",
-      "headline": "How to Replace whatsapp-web.js with whatsmeow-node",
-      "description": "Migrate from whatsapp-web.js to whatsmeow-node — drop Puppeteer, cut memory from 500 MB to 20 MB, and get a typed async API.",
+      "headline": "Cómo Reemplazar whatsapp-web.js con whatsmeow-node",
+      "description": "Migra de whatsapp-web.js a whatsmeow-node — elimina Puppeteer, reduce la memoria de 500 MB a 20 MB y obtén una API async tipada.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/migrate-from-whatsapp-web-js.png",
       "author": {"@type": "Organization", "name": "whatsmeow-node", "url": "https://nicastelo.github.io/whatsmeow-node/"},
       "publisher": {"@type": "Organization", "name": "whatsmeow-node", "logo": {"@type": "ImageObject", "url": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/migrate-from-whatsapp-web-js.png"}}

--- a/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/migrate-from-whatsapp-web-js.md
+++ b/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/migrate-from-whatsapp-web-js.md
@@ -1,0 +1,322 @@
+---
+title: "Cómo Reemplazar whatsapp-web.js con whatsmeow-node"
+sidebar_label: Migrar desde whatsapp-web.js
+sidebar_position: 11
+description: "Migra de whatsapp-web.js a whatsmeow-node — elimina Puppeteer, reduce la memoria de 500 MB a 20 MB y obtén una API async tipada."
+keywords: [alternativa whatsapp-web.js, reemplazar whatsapp-web.js, whatsapp-web.js a whatsmeow, migración whatsapp-web.js, bot whatsapp sin puppeteer, bot whatsapp sin navegador]
+---
+
+import Head from '@docusaurus/Head';
+import {RelatedGuides} from '@site/src/components/RelatedGuides';
+
+<Head>
+  <meta property="og:image" content="https://nicastelo.github.io/whatsmeow-node/img/guides/es/migrate-from-whatsapp-web-js.png" />
+  <meta name="twitter:image" content="https://nicastelo.github.io/whatsmeow-node/img/guides/es/migrate-from-whatsapp-web-js.png" />
+  <script type="application/ld+json">
+    {JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "HowTo",
+      "name": "How to Replace whatsapp-web.js with whatsmeow-node",
+      "description": "Migrate from whatsapp-web.js to whatsmeow-node — drop Puppeteer, cut memory from 500 MB to 20 MB, and get a typed async API.",
+      "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/migrate-from-whatsapp-web-js.png",
+      "step": [
+        {"@type": "HowToStep", "name": "Install whatsmeow-node", "text": "Replace whatsapp-web.js and puppeteer with @whatsmeow-node/whatsmeow-node."},
+        {"@type": "HowToStep", "name": "Update Client Initialization", "text": "Replace new Client() with createClient(). No LocalAuth or Puppeteer configuration needed."},
+        {"@type": "HowToStep", "name": "Update Event Listeners", "text": "Replace client.on('message') callback shapes and update message property access patterns."},
+        {"@type": "HowToStep", "name": "Update Message Sending", "text": "Replace client.sendMessage() with the whatsmeow-node sendMessage or sendRawMessage methods."},
+        {"@type": "HowToStep", "name": "Remove Browser Dependencies", "text": "Remove Puppeteer, Chromium, and any browser-related configuration from your project."}
+      ]
+    })}
+  </script>
+  <script type="application/ld+json">
+    {JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "Article",
+      "headline": "How to Replace whatsapp-web.js with whatsmeow-node",
+      "description": "Migrate from whatsapp-web.js to whatsmeow-node — drop Puppeteer, cut memory from 500 MB to 20 MB, and get a typed async API.",
+      "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/migrate-from-whatsapp-web-js.png",
+      "author": {"@type": "Organization", "name": "whatsmeow-node", "url": "https://nicastelo.github.io/whatsmeow-node/"},
+      "publisher": {"@type": "Organization", "name": "whatsmeow-node", "logo": {"@type": "ImageObject", "url": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/migrate-from-whatsapp-web-js.png"}}
+    })}
+  </script>
+</Head>
+
+![Cómo Reemplazar whatsapp-web.js con whatsmeow-node](/img/guides/es/migrate-from-whatsapp-web-js.png)
+![Cómo Reemplazar whatsapp-web.js con whatsmeow-node](/img/guides/es/migrate-from-whatsapp-web-js-light.png)
+
+# Cómo Reemplazar whatsapp-web.js con whatsmeow-node
+
+[whatsapp-web.js](https://github.com/pedroslopez/whatsapp-web.js) ejecuta un navegador Chrome headless para automatizar WhatsApp Web. Funciona, pero es pesado — 200-500 MB de RAM solo para el navegador, arranque lento, y se rompe cuando WhatsApp actualiza su cliente web. whatsmeow-node usa el protocolo nativo multi-dispositivo directamente, sin necesidad de navegador.
+
+## ¿Por Qué Migrar?
+
+| | whatsapp-web.js | whatsmeow-node |
+|---|---|---|
+| **Memoria** | 200-500 MB (Chromium) | ~10-20 MB |
+| **Arranque** | 5-15 segundos (lanzamiento del navegador) | Menos de 1 segundo |
+| **Dependencias** | Puppeteer + Chromium | Un solo binario Go (incluido) |
+| **Protocolo** | Automatización del cliente web | Multi-dispositivo nativo |
+| **Estabilidad** | Se rompe con actualizaciones de WhatsApp Web | Upstream estable (whatsmeow) |
+| **Imagen Docker** | ~1 GB+ (necesita Chrome) | ~50 MB |
+| **TypeScript** | Types de la comunidad | TypeScript nativo |
+
+## Paso 1: Instalar
+
+```bash
+# Remove whatsapp-web.js and Puppeteer
+npm uninstall whatsapp-web.js puppeteer
+
+# Install whatsmeow-node
+npm install @whatsmeow-node/whatsmeow-node
+```
+
+También puedes eliminar cualquier dependencia relacionada con Chromium o capas de Docker.
+
+## Paso 2: Actualizar la Inicialización del Cliente
+
+### whatsapp-web.js
+
+```javascript
+const { Client, LocalAuth } = require("whatsapp-web.js");
+
+const client = new Client({
+  authStrategy: new LocalAuth(),
+  puppeteer: {
+    headless: true,
+    args: ["--no-sandbox"],
+  },
+});
+
+client.on("qr", (qr) => {
+  qrcode.generate(qr, { small: true });
+});
+
+client.on("ready", () => {
+  console.log("Client is ready!");
+});
+
+client.initialize();
+```
+
+### whatsmeow-node
+
+```typescript
+import { createClient } from "@whatsmeow-node/whatsmeow-node";
+import qrcode from "qrcode-terminal";
+
+const client = createClient({ store: "session.db" });
+
+async function main() {
+  const { jid } = await client.init();
+
+  if (jid) {
+    await client.connect();
+    console.log("Client is ready!");
+  } else {
+    client.on("qr", ({ code }) => qrcode.generate(code, { small: true }));
+    await client.getQRChannel();
+    await client.connect();
+  }
+}
+
+main().catch(console.error);
+```
+
+Sin configuración de Puppeteer, sin estrategia de autenticación, sin `initialize()` — solo `init()` + `connect()`.
+
+## Paso 3: Actualizar los Listeners de Eventos
+
+### Mensajes
+
+**whatsapp-web.js:**
+```javascript
+client.on("message", async (msg) => {
+  if (msg.fromMe) return;
+  console.log(`${msg.from}: ${msg.body}`);
+
+  if (msg.body === "!ping") {
+    await msg.reply("pong");
+  }
+});
+```
+
+**whatsmeow-node:**
+```typescript
+client.on("message", async ({ info, message }) => {
+  if (info.isFromMe) return;
+
+  const text =
+    (message.conversation as string) ??
+    (message.extendedTextMessage as { text?: string } | undefined)?.text;
+  if (!text) return;
+
+  console.log(`${info.chat}: ${text}`);
+
+  if (text === "!ping") {
+    await client.sendMessage(info.chat, { conversation: "pong" });
+  }
+});
+```
+
+Diferencias clave:
+- Sin atajo `msg.body` — el texto se extrae del mensaje protobuf
+- Sin `msg.reply()` — usa `sendMessage()` o `sendRawMessage()` con `contextInfo` para citas
+- `msg.from` → `info.chat`, `msg.fromMe` → `info.isFromMe`
+
+### Eventos de conexión
+
+**whatsapp-web.js:**
+```javascript
+client.on("ready", () => console.log("Ready"));
+client.on("disconnected", (reason) => console.log("Disconnected:", reason));
+```
+
+**whatsmeow-node:**
+```typescript
+client.on("connected", ({ jid }) => console.log(`Connected as ${jid}`));
+client.on("disconnected", () => console.log("Disconnected"));
+client.on("logged_out", ({ reason }) => console.error(`Logged out: ${reason}`));
+```
+
+## Paso 4: Actualizar el Envío de Mensajes
+
+### Texto
+
+**whatsapp-web.js:**
+```javascript
+await client.sendMessage(chatId, "Hello!");
+```
+
+**whatsmeow-node:**
+```typescript
+await client.sendMessage(jid, { conversation: "Hello!" });
+```
+
+### Respuesta con cita
+
+**whatsapp-web.js:**
+```javascript
+await msg.reply("Got it!");
+```
+
+**whatsmeow-node:**
+```typescript
+await client.sendRawMessage(info.chat, {
+  extendedTextMessage: {
+    text: "Got it!",
+    contextInfo: {
+      stanzaId: info.id,
+      participant: info.sender,
+      quotedMessage: { conversation: originalText },
+    },
+  },
+});
+```
+
+### Multimedia
+
+**whatsapp-web.js:**
+```javascript
+const media = MessageMedia.fromFilePath("/path/to/photo.jpg");
+await client.sendMessage(chatId, media, { caption: "Check this out" });
+```
+
+**whatsmeow-node:**
+```typescript
+const media = await client.uploadMedia("/path/to/photo.jpg", "image");
+await client.sendRawMessage(jid, {
+  imageMessage: {
+    URL: media.URL,
+    directPath: media.directPath,
+    mediaKey: media.mediaKey,
+    fileEncSHA256: media.fileEncSHA256,
+    fileSHA256: media.fileSHA256,
+    fileLength: String(media.fileLength),
+    mimetype: "image/jpeg",
+    caption: "Check this out",
+  },
+});
+```
+
+### Reacciones
+
+**whatsapp-web.js:**
+```javascript
+await msg.react("👍");
+```
+
+**whatsmeow-node:**
+```typescript
+await client.sendReaction(chat, sender, messageId, "👍");
+```
+
+## Paso 5: Actualizar Operaciones de Grupo
+
+| whatsapp-web.js | whatsmeow-node |
+|-----------------|----------------|
+| `client.createGroup(name, members)` | `client.createGroup(name, members)` |
+| `chat.fetchMessages()` | — (usa el evento message) |
+| `groupChat.addParticipants([id])` | `client.updateGroupParticipants(jid, [id], "add")` |
+| `groupChat.removeParticipants([id])` | `client.updateGroupParticipants(jid, [id], "remove")` |
+| `groupChat.promoteParticipants([id])` | `client.updateGroupParticipants(jid, [id], "promote")` |
+| `groupChat.setSubject(name)` | `client.setGroupName(jid, name)` |
+| `groupChat.setDescription(desc)` | `client.setGroupDescription(jid, desc)` |
+| `groupChat.leave()` | `client.leaveGroup(jid)` |
+| `groupChat.getInviteCode()` | `client.getGroupInviteLink(jid)` |
+
+## Paso 6: Limpiar
+
+Después de migrar, puedes eliminar de tu proyecto:
+
+- Dependencia de `puppeteer` / `puppeteer-core`
+- Scripts de descarga de Chromium o capas de Docker
+- Directorio `.wwebjs_auth/` (datos de sesión de LocalAuth)
+- Cualquier configuración de flags de Chrome como `--no-sandbox`, `--disable-gpu`
+- Configuración de CI/CD específica del navegador (Xvfb, etc.)
+
+Tus imágenes Docker se reducirán drásticamente sin Chromium.
+
+## Diferencias en el Formato de JID
+
+whatsapp-web.js usa `number@c.us` para contactos. whatsmeow-node usa `number@s.whatsapp.net`:
+
+```typescript
+// whatsapp-web.js
+const chatId = "5512345678@c.us";
+
+// whatsmeow-node
+const jid = "5512345678@s.whatsapp.net";
+```
+
+Los JID de grupos mantienen el mismo formato: `120363XXXXX@g.us`.
+
+## Lista de Verificación de Migración
+
+- [ ] Instalar `@whatsmeow-node/whatsmeow-node`, eliminar `whatsapp-web.js` y `puppeteer`
+- [ ] Reemplazar `new Client()` → `createClient()`
+- [ ] Eliminar configuración de Puppeteer y `LocalAuth`
+- [ ] Actualizar listeners de eventos (nombres y formas de eventos diferentes)
+- [ ] Reemplazar `msg.body` con extracción del mensaje protobuf
+- [ ] Reemplazar `msg.reply()` con `sendMessage()` / `sendRawMessage()`
+- [ ] Reemplazar `client.sendMessage(id, text)` con `sendMessage(jid, { conversation: text })`
+- [ ] Actualizar formato de JID: `@c.us` → `@s.whatsapp.net`
+- [ ] Actualizar envío de multimedia (upload + envío separados)
+- [ ] Eliminar Chromium de Docker / CI
+- [ ] Vincular de nuevo vía QR code
+- [ ] Probar todos los tipos de mensaje de extremo a extremo
+
+## Errores Comunes
+
+:::warning Se requiere nueva sesión
+Las sesiones de whatsapp-web.js no se pueden migrar. Debes vincular de nuevo escaneando el QR code. Tus datos de WhatsApp no se ven afectados.
+:::
+
+:::warning Sin `msg.body`
+whatsapp-web.js te da `msg.body` como conveniencia. whatsmeow-node te da el protobuf crudo, así que el texto puede estar en `message.conversation` o `message.extendedTextMessage.text`. Siempre verifica ambos.
+:::
+
+:::warning Formato de JID
+whatsapp-web.js usa `@c.us` para contactos. whatsmeow-node usa `@s.whatsapp.net`. Si tienes JID almacenados, actualízalos.
+:::
+
+<RelatedGuides slugs={["whatsmeow-in-node", "build-a-bot", "migrate-from-baileys"]} />

--- a/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/pair-whatsapp.md
+++ b/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/pair-whatsapp.md
@@ -19,10 +19,10 @@ import Head from '@docusaurus/Head';
       "description": "Vincula una cuenta de WhatsApp a tu aplicación Node.js usando escaneo de QR code o ingreso de código por número telefónico. Incluye persistencia de sesión y reconexión.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/pair-whatsapp.png",
       "step": [
-        {"@type": "HowToStep", "name": "QR Code Pairing", "text": "Call getQRChannel() then connect(). Listen for the qr event and render the code with qrcode-terminal."},
-        {"@type": "HowToStep", "name": "Phone Number Pairing", "text": "Call connect() first, then pairCode(phoneNumber). The user enters the 8-digit code in WhatsApp."},
-        {"@type": "HowToStep", "name": "Session Persistence", "text": "The session is stored in the database. On next run, init() returns the stored JID and you skip pairing."},
-        {"@type": "HowToStep", "name": "Choose a Store", "text": "Use SQLite (session.db) for development or PostgreSQL for production."}
+        {"@type": "HowToStep", "name": "Vinculación por QR Code", "text": "Llama a getQRChannel() y luego connect(). Escucha el evento qr y muestra el código con qrcode-terminal."},
+        {"@type": "HowToStep", "name": "Vinculación por número telefónico", "text": "Llama primero a connect(), luego a pairCode(phoneNumber). El usuario ingresa el código de 8 dígitos en WhatsApp."},
+        {"@type": "HowToStep", "name": "Persistencia de sesión", "text": "La sesión se almacena en la base de datos. En la siguiente ejecución, init() devuelve el JID almacenado y omites la vinculación."},
+        {"@type": "HowToStep", "name": "Elegir un almacén", "text": "Usa SQLite (session.db) para desarrollo o PostgreSQL para producción."}
       ]
     })}
   </script>

--- a/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/poll-bot.md
+++ b/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/poll-bot.md
@@ -16,14 +16,14 @@ import {RelatedGuides} from '@site/src/components/RelatedGuides';
     {JSON.stringify({
       "@context": "https://schema.org",
       "@type": "HowTo",
-      "name": "How to Create a WhatsApp Poll Bot",
-      "description": "Create and manage WhatsApp polls programmatically with Node.js — send polls, read votes, announce results, and build interactive group bots with whatsmeow-node.",
+      "name": "Cómo Crear un Bot de Encuestas de WhatsApp",
+      "description": "Crea y administra encuestas de WhatsApp programáticamente con Node.js — envía encuestas, lee votos, anuncia resultados y construye bots interactivos de grupo con whatsmeow-node.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/poll-bot.png",
       "step": [
-        {"@type": "HowToStep", "name": "Create a Poll", "text": "Use sendPollCreation() with a question, options array, and max selectable count."},
-        {"@type": "HowToStep", "name": "Listen for Votes", "text": "Handle incoming poll vote messages and decrypt them with decryptPollVote()."},
-        {"@type": "HowToStep", "name": "Track Results", "text": "Store votes in a Map and tally results per poll."},
-        {"@type": "HowToStep", "name": "Announce Results", "text": "Send a summary message with the vote counts when the poll closes."}
+        {"@type": "HowToStep", "name": "Crear una encuesta", "text": "Usa sendPollCreation() con una pregunta, un arreglo de opciones y el conteo máximo seleccionable."},
+        {"@type": "HowToStep", "name": "Escuchar los votos", "text": "Maneja los mensajes entrantes de votos de encuesta y descifra con decryptPollVote()."},
+        {"@type": "HowToStep", "name": "Rastrear resultados", "text": "Almacena los votos en un Map y contabiliza los resultados por encuesta."},
+        {"@type": "HowToStep", "name": "Anunciar resultados", "text": "Envía un mensaje resumen con el conteo de votos cuando la encuesta se cierre."}
       ]
     })}
   </script>
@@ -31,8 +31,8 @@ import {RelatedGuides} from '@site/src/components/RelatedGuides';
     {JSON.stringify({
       "@context": "https://schema.org",
       "@type": "Article",
-      "headline": "How to Create a WhatsApp Poll Bot",
-      "description": "Create and manage WhatsApp polls programmatically with Node.js — send polls, read votes, announce results, and build interactive group bots with whatsmeow-node.",
+      "headline": "Cómo Crear un Bot de Encuestas de WhatsApp",
+      "description": "Crea y administra encuestas de WhatsApp programáticamente con Node.js — envía encuestas, lee votos, anuncia resultados y construye bots interactivos de grupo con whatsmeow-node.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/poll-bot.png",
       "author": {"@type": "Organization", "name": "whatsmeow-node", "url": "https://nicastelo.github.io/whatsmeow-node/"},
       "publisher": {"@type": "Organization", "name": "whatsmeow-node", "logo": {"@type": "ImageObject", "url": "https://nicastelo.github.io/whatsmeow-node/img/image.png"}}

--- a/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/poll-bot.md
+++ b/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/poll-bot.md
@@ -1,0 +1,350 @@
+---
+title: "Cómo Crear un Bot de Encuestas de WhatsApp"
+sidebar_label: Bot de Encuestas
+sidebar_position: 19
+description: "Crea y administra encuestas de WhatsApp programáticamente con Node.js — envía encuestas, lee votos, anuncia resultados y construye bots interactivos de grupo con whatsmeow-node."
+keywords: [bot encuestas whatsapp, crear encuesta whatsapp api, encuesta whatsapp nodejs, votar encuesta whatsapp api, bot encuestas whatsapp typescript]
+---
+
+import Head from '@docusaurus/Head';
+import {RelatedGuides} from '@site/src/components/RelatedGuides';
+
+<Head>
+  <meta property="og:image" content="https://nicastelo.github.io/whatsmeow-node/img/guides/es/poll-bot.png" />
+  <meta name="twitter:image" content="https://nicastelo.github.io/whatsmeow-node/img/guides/es/poll-bot.png" />
+  <script type="application/ld+json">
+    {JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "HowTo",
+      "name": "How to Create a WhatsApp Poll Bot",
+      "description": "Create and manage WhatsApp polls programmatically with Node.js — send polls, read votes, announce results, and build interactive group bots with whatsmeow-node.",
+      "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/poll-bot.png",
+      "step": [
+        {"@type": "HowToStep", "name": "Create a Poll", "text": "Use sendPollCreation() with a question, options array, and max selectable count."},
+        {"@type": "HowToStep", "name": "Listen for Votes", "text": "Handle incoming poll vote messages and decrypt them with decryptPollVote()."},
+        {"@type": "HowToStep", "name": "Track Results", "text": "Store votes in a Map and tally results per poll."},
+        {"@type": "HowToStep", "name": "Announce Results", "text": "Send a summary message with the vote counts when the poll closes."}
+      ]
+    })}
+  </script>
+  <script type="application/ld+json">
+    {JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "Article",
+      "headline": "How to Create a WhatsApp Poll Bot",
+      "description": "Create and manage WhatsApp polls programmatically with Node.js — send polls, read votes, announce results, and build interactive group bots with whatsmeow-node.",
+      "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/poll-bot.png",
+      "author": {"@type": "Organization", "name": "whatsmeow-node", "url": "https://nicastelo.github.io/whatsmeow-node/"},
+      "publisher": {"@type": "Organization", "name": "whatsmeow-node", "logo": {"@type": "ImageObject", "url": "https://nicastelo.github.io/whatsmeow-node/img/image.png"}}
+    })}
+  </script>
+</Head>
+
+![Cómo Crear un Bot de Encuestas de WhatsApp](/img/guides/es/poll-bot.png)
+![Cómo Crear un Bot de Encuestas de WhatsApp](/img/guides/es/poll-bot-light.png)
+
+# Cómo Crear un Bot de Encuestas de WhatsApp
+
+whatsmeow-node te permite crear encuestas, recibir votos cifrados, descifrarlos y contabilizar resultados — todo programáticamente. Esto es ideal para bots de grupo que manejan votaciones, encuestas o flujos de toma de decisiones.
+
+## Requisitos Previos
+
+- Una sesión vinculada de whatsmeow-node ([Cómo Vincular](pair-whatsapp))
+- Un grupo para probar (las encuestas funcionan mejor en chats de grupo)
+
+## Paso 1: Crear una Encuesta
+
+```typescript
+const resp = await client.sendPollCreation(
+  groupJid,
+  "Where should we eat?",         // question
+  ["Pizza", "Sushi", "Tacos"],    // options
+  1,                               // max selectable (1 = single choice)
+);
+
+console.log(`Poll sent with ID: ${resp.id}`);
+```
+
+Configura `selectableCount` para permitir selecciones múltiples:
+
+```typescript
+// Multi-select poll — voters can pick up to 3
+await client.sendPollCreation(
+  groupJid,
+  "Which topics should we cover?",
+  ["Frontend", "Backend", "DevOps", "Mobile", "AI"],
+  3,
+);
+```
+
+## Paso 2: Escuchar los Votos
+
+Los votos de encuesta llegan como eventos `message` con datos de voto cifrados. Usa `decryptPollVote()` para leerlos.
+
+:::warning Hashes de votos
+`decryptPollVote()` devuelve `selectedOptions` como **hashes SHA-256** (codificados en base64), no texto de opción. Debes hashear tus opciones conocidas y comparar para identificar qué opciones fueron seleccionadas.
+:::
+
+```typescript
+import { createHash } from "node:crypto";
+
+// Hash an option name the same way WhatsApp does
+function hashOption(option: string): string {
+  return createHash("sha256").update(option).digest("base64");
+}
+
+client.on("message", async ({ info, message }) => {
+  const pollUpdate = message.pollUpdateMessage as Record<string, unknown> | undefined;
+  if (!pollUpdate) return;
+
+  // Get the poll message ID from the poll update
+  const pollKey = pollUpdate.pollCreationMessageKey as { id?: string } | undefined;
+  const pollId = pollKey?.id;
+  if (!pollId) return;
+
+  try {
+    const vote = await client.decryptPollVote(
+        info as unknown as Record<string, unknown>,
+        message,
+      );
+    const hashes = (vote.selectedOptions ?? []) as string[];
+    console.log(`${info.sender} voted (${hashes.length} options)`);
+  } catch (err) {
+    console.error("Failed to decrypt poll vote:", err);
+  }
+});
+```
+
+## Paso 3: Rastrear Resultados
+
+Almacena las encuestas con un mapa hash→opción para poder resolver los hashes de votos a nombres de opciones:
+
+```typescript
+import { createHash } from "node:crypto";
+
+function hashOption(option: string): string {
+  return createHash("sha256").update(option).digest("base64");
+}
+
+type PollData = {
+  question: string;
+  hashToOption: Map<string, string>; // SHA-256 hash → option name
+  results: Map<string, string[]>;    // option name → voter JIDs
+};
+
+const polls = new Map<string, PollData>();
+
+// When creating a poll, store option hashes
+async function createPoll(groupJid: string, question: string, options: string[]) {
+  const resp = await client.sendPollCreation(groupJid, question, options, 1);
+
+  const hashToOption = new Map<string, string>();
+  const results = new Map<string, string[]>();
+  for (const opt of options) {
+    hashToOption.set(hashOption(opt), opt);
+    results.set(opt, []);
+  }
+
+  polls.set(resp.id, { question, hashToOption, results });
+  return resp;
+}
+
+// When receiving a vote, resolve hashes and tally
+function recordVote(pollId: string, voter: string, selectedHashes: string[]) {
+  const poll = polls.get(pollId);
+  if (!poll) return;
+
+  // Remove previous votes from this voter
+  for (const [, voters] of poll.results) {
+    const idx = voters.indexOf(voter);
+    if (idx !== -1) voters.splice(idx, 1);
+  }
+
+  // Resolve hashes to option names and add votes
+  for (const hash of selectedHashes) {
+    const option = poll.hashToOption.get(hash);
+    if (option) {
+      poll.results.get(option)?.push(voter);
+    }
+  }
+}
+```
+
+## Paso 4: Anunciar Resultados
+
+Envía un resumen con el comando `!results`:
+
+```typescript
+function formatResults(pollId: string): string | null {
+  const poll = polls.get(pollId);
+  if (!poll) return null;
+
+  let text = `Poll: ${poll.question}\n\n`;
+
+  const sorted = [...poll.results.entries()].sort((a, b) => b[1].length - a[1].length);
+
+  for (const [option, voters] of sorted) {
+    const bar = "█".repeat(voters.length);
+    text += `${option}: ${bar} ${voters.length}\n`;
+  }
+
+  const total = sorted.reduce((sum, [, v]) => sum + v.length, 0);
+  text += `\nTotal votes: ${total}`;
+
+  return text;
+}
+```
+
+## Ejemplo Completo
+
+Un bot de grupo que maneja los comandos `!poll` y `!results`:
+
+```typescript
+import { createClient } from "@whatsmeow-node/whatsmeow-node";
+import { createHash } from "node:crypto";
+
+const client = createClient({ store: "session.db" });
+
+function hashOption(option: string): string {
+  return createHash("sha256").update(option).digest("base64");
+}
+
+type PollData = {
+  question: string;
+  chat: string;
+  hashToOption: Map<string, string>;
+  results: Map<string, string[]>;
+};
+
+const polls = new Map<string, PollData>();
+let lastPollId: string | null = null;
+
+client.on("message", async ({ info, message }) => {
+  if (info.isFromMe) return;
+
+  // Handle poll votes
+  const pollUpdate = message.pollUpdateMessage as Record<string, unknown> | undefined;
+  if (pollUpdate) {
+    const pollKey = pollUpdate.pollCreationMessageKey as { id?: string } | undefined;
+    const pollId = pollKey?.id;
+    if (!pollId) return;
+
+    const poll = polls.get(pollId);
+    if (!poll) return;
+
+    try {
+      const vote = await client.decryptPollVote(
+        info as unknown as Record<string, unknown>,
+        message,
+      );
+      const selectedHashes = (vote.selectedOptions ?? []) as string[];
+
+      // Remove previous votes from this voter
+      for (const [, voters] of poll.results) {
+        const idx = voters.indexOf(info.sender);
+        if (idx !== -1) voters.splice(idx, 1);
+      }
+
+      // Resolve hashes to option names and tally
+      for (const hash of selectedHashes) {
+        const option = poll.hashToOption.get(hash);
+        if (option) {
+          poll.results.get(option)?.push(info.sender);
+        }
+      }
+    } catch {
+      // Ignore decryption errors for polls we don't track
+    }
+    return;
+  }
+
+  // Handle text commands
+  const text =
+    (message.conversation as string) ??
+    (message.extendedTextMessage as { text?: string } | undefined)?.text;
+  if (!text?.startsWith("!")) return;
+
+  // !poll Where should we eat? | Pizza | Sushi | Tacos
+  if (text.startsWith("!poll ")) {
+    const parts = text.slice(6).split("|").map((s) => s.trim());
+    if (parts.length < 3) {
+      await client.sendMessage(info.chat, {
+        conversation: "Usage: !poll Question | Option 1 | Option 2 | ...",
+      });
+      return;
+    }
+
+    const [question, ...options] = parts;
+    const resp = await client.sendPollCreation(info.chat, question, options, 1);
+
+    const hashToOption = new Map<string, string>();
+    const results = new Map<string, string[]>();
+    for (const opt of options) {
+      hashToOption.set(hashOption(opt), opt);
+      results.set(opt, []);
+    }
+    polls.set(resp.id, { question, chat: info.chat, hashToOption, results });
+    lastPollId = resp.id;
+
+    return;
+  }
+
+  // !results — show results for the last poll
+  if (text === "!results") {
+    if (!lastPollId || !polls.has(lastPollId)) {
+      await client.sendMessage(info.chat, {
+        conversation: "No active poll. Create one with !poll",
+      });
+      return;
+    }
+
+    const poll = polls.get(lastPollId)!;
+    let summary = `Poll: ${poll.question}\n\n`;
+    const sorted = [...poll.results.entries()].sort((a, b) => b[1].length - a[1].length);
+    for (const [option, voters] of sorted) {
+      summary += `${option}: ${"█".repeat(voters.length)} ${voters.length}\n`;
+    }
+    const total = sorted.reduce((sum, [, v]) => sum + v.length, 0);
+    summary += `\nTotal votes: ${total}`;
+
+    await client.sendMessage(info.chat, { conversation: summary });
+    return;
+  }
+});
+
+async function main() {
+  const { jid } = await client.init();
+  if (!jid) {
+    console.error("Not paired!");
+    process.exit(1);
+  }
+  await client.connect();
+  await client.sendPresence("available");
+  console.log("Poll bot is online! Commands: !poll, !results");
+
+  process.on("SIGINT", async () => {
+    await client.sendPresence("unavailable");
+    await client.disconnect();
+    client.close();
+    process.exit(0);
+  });
+}
+
+main().catch(console.error);
+```
+
+## Errores Comunes
+
+:::warning Los votos de encuesta están cifrados
+Debes llamar a `decryptPollVote()` para leer los votos. El `pollUpdateMessage` crudo contiene datos cifrados que no se pueden leer sin descifrado.
+:::
+
+:::warning Resultados en memoria
+El ejemplo almacena datos de encuestas en un `Map` que se pierde al reiniciar. Para producción, persiste las encuestas y votos en una base de datos.
+:::
+
+:::warning Bucles de eco
+Siempre verifica `info.isFromMe`. El bot crea encuestas que disparan eventos de mensaje — sin esta verificación, podría reaccionar a sus propias encuestas.
+:::
+
+<RelatedGuides slugs={["automate-group-messages", "build-a-bot", "send-messages-typescript"]} />

--- a/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/schedule-messages.md
+++ b/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/schedule-messages.md
@@ -1,0 +1,273 @@
+---
+title: "Cómo Programar Mensajes de WhatsApp con Node.js"
+sidebar_label: Programar Mensajes
+sidebar_position: 18
+description: "Programa mensajes de WhatsApp para enviar a una hora específica con Node.js — envíos diferidos, recordatorios recurrentes y programación con cron usando whatsmeow-node."
+keywords: [programar mensajes whatsapp nodejs, whatsapp mensajes programados api, whatsapp cron job, mensaje whatsapp diferido, bot recordatorio whatsapp nodejs]
+---
+
+import Head from '@docusaurus/Head';
+import {RelatedGuides} from '@site/src/components/RelatedGuides';
+
+<Head>
+  <meta property="og:image" content="https://nicastelo.github.io/whatsmeow-node/img/guides/es/schedule-messages.png" />
+  <meta name="twitter:image" content="https://nicastelo.github.io/whatsmeow-node/img/guides/es/schedule-messages.png" />
+  <script type="application/ld+json">
+    {JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "HowTo",
+      "name": "How to Schedule WhatsApp Messages with Node.js",
+      "description": "Schedule WhatsApp messages to send at a specific time with Node.js — delayed sends, recurring reminders, and cron-based scheduling using whatsmeow-node.",
+      "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/schedule-messages.png",
+      "step": [
+        {"@type": "HowToStep", "name": "Send a Delayed Message", "text": "Use setTimeout to send a message after a delay."},
+        {"@type": "HowToStep", "name": "Schedule at a Specific Time", "text": "Calculate the delay from now until the target time and use setTimeout."},
+        {"@type": "HowToStep", "name": "Set Up Recurring Messages", "text": "Use node-cron to send messages on a cron schedule — daily reminders, weekly reports."},
+        {"@type": "HowToStep", "name": "Build a User-Facing Scheduler", "text": "Let users schedule messages via WhatsApp commands like !remind 30m Take a break."}
+      ]
+    })}
+  </script>
+  <script type="application/ld+json">
+    {JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "Article",
+      "headline": "How to Schedule WhatsApp Messages with Node.js",
+      "description": "Schedule WhatsApp messages to send at a specific time with Node.js — delayed sends, recurring reminders, and cron-based scheduling using whatsmeow-node.",
+      "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/schedule-messages.png",
+      "author": {"@type": "Organization", "name": "whatsmeow-node", "url": "https://nicastelo.github.io/whatsmeow-node/"},
+      "publisher": {"@type": "Organization", "name": "whatsmeow-node", "logo": {"@type": "ImageObject", "url": "https://nicastelo.github.io/whatsmeow-node/img/image.png"}}
+    })}
+  </script>
+</Head>
+
+![Cómo Programar Mensajes de WhatsApp con Node.js](/img/guides/es/schedule-messages.png)
+![Cómo Programar Mensajes de WhatsApp con Node.js](/img/guides/es/schedule-messages-light.png)
+
+# Cómo Programar Mensajes de WhatsApp con Node.js
+
+WhatsApp no tiene una API de programación incorporada, pero puedes construir una con whatsmeow-node y herramientas estándar de programación de Node.js — `setTimeout` para delays únicos, `node-cron` para mensajes recurrentes, o una cola respaldada por base de datos para persistencia.
+
+## Requisitos Previos
+
+- Una sesión vinculada de whatsmeow-node ([Cómo Vincular](pair-whatsapp))
+- Para programaciones recurrentes: `npm install node-cron`
+
+## Enviar un Mensaje Diferido
+
+El enfoque más simple — envía un mensaje después de un delay:
+
+```typescript
+function sendLater(jid: string, message: string, delayMs: number) {
+  setTimeout(async () => {
+    await client.sendMessage(jid, { conversation: message });
+    console.log(`Sent scheduled message to ${jid}`);
+  }, delayMs);
+}
+
+// Send in 30 minutes
+sendLater("5512345678@s.whatsapp.net", "Time's up!", 30 * 60 * 1000);
+```
+
+## Programar a una Hora Específica
+
+Calcula el delay desde ahora hasta la hora objetivo:
+
+```typescript
+function sendAt(jid: string, message: string, date: Date) {
+  const delay = date.getTime() - Date.now();
+
+  if (delay <= 0) {
+    console.error("Scheduled time is in the past");
+    return;
+  }
+
+  console.log(`Scheduled for ${date.toLocaleString()} (in ${Math.round(delay / 1000)}s)`);
+
+  setTimeout(async () => {
+    await client.sendMessage(jid, { conversation: message });
+  }, delay);
+}
+
+// Send tomorrow at 9 AM
+const tomorrow9am = new Date();
+tomorrow9am.setDate(tomorrow9am.getDate() + 1);
+tomorrow9am.setHours(9, 0, 0, 0);
+
+sendAt("5512345678@s.whatsapp.net", "Good morning! Don't forget the meeting at 10.", tomorrow9am);
+```
+
+## Configurar Mensajes Recurrentes con Cron
+
+Usa `node-cron` para programaciones recurrentes:
+
+```bash
+npm install node-cron
+```
+
+```typescript
+import cron from "node-cron";
+
+// Every weekday at 8:55 AM — "standup in 5 minutes"
+cron.schedule("55 8 * * 1-5", async () => {
+  const groupJid = "120363XXXXX@g.us";
+  await client.sendMessage(groupJid, {
+    conversation: "Standup in 5 minutes!",
+  });
+});
+
+// Every Monday at 9 AM — weekly report
+cron.schedule("0 9 * * 1", async () => {
+  const reportChat = "5512345678@s.whatsapp.net";
+  await client.sendMessage(reportChat, {
+    conversation: "Weekly report is ready: https://example.com/reports/latest",
+  });
+});
+
+// First day of every month — billing reminder
+cron.schedule("0 10 1 * *", async () => {
+  const billingGroup = "120363YYYYY@g.us";
+  await client.sendMessage(billingGroup, {
+    conversation: "Reminder: invoices are due by the 5th",
+  });
+});
+```
+
+:::info Sintaxis cron
+`node-cron` usa el formato estándar de cron: `minuto hora día-del-mes mes día-de-la-semana`. Usa [crontab.guru](https://crontab.guru/) para construir expresiones.
+:::
+
+## Crear un Programador para Usuarios
+
+Permite que los usuarios programen recordatorios vía comandos de WhatsApp:
+
+```typescript
+client.on("message", async ({ info, message }) => {
+  if (info.isFromMe) return;
+
+  const text =
+    (message.conversation as string) ??
+    (message.extendedTextMessage as { text?: string } | undefined)?.text;
+  if (!text?.startsWith("!remind")) return;
+
+  // Parse: !remind 30m Take a break
+  const match = text.match(/^!remind\s+(\d+)(m|h|s)\s+(.+)$/);
+  if (!match) {
+    await client.sendMessage(info.chat, {
+      conversation: "Usage: !remind <number><m|h|s> <message>\nExample: !remind 30m Take a break",
+    });
+    return;
+  }
+
+  const [, amount, unit, reminder] = match;
+  const multiplier = { s: 1000, m: 60_000, h: 3_600_000 }[unit]!;
+  const delayMs = parseInt(amount) * multiplier;
+
+  setTimeout(async () => {
+    await client.sendRawMessage(info.chat, {
+      extendedTextMessage: {
+        text: `Reminder: ${reminder}`,
+        contextInfo: {
+          mentionedJid: [info.sender],
+        },
+      },
+    });
+  }, delayMs);
+
+  const delayText = `${amount}${unit}`;
+  await client.sendMessage(info.chat, {
+    conversation: `Got it! I'll remind you in ${delayText}: "${reminder}"`,
+  });
+});
+```
+
+## Ejemplo Completo
+
+Un bot programador con comandos `!remind` y un cron diario:
+
+```typescript
+import { createClient } from "@whatsmeow-node/whatsmeow-node";
+import cron from "node-cron";
+
+const client = createClient({ store: "session.db" });
+
+// Daily standup reminder
+cron.schedule("55 8 * * 1-5", async () => {
+  const group = "120363XXXXX@g.us";
+  await client.sendMessage(group, {
+    conversation: "Standup in 5 minutes!",
+  });
+});
+
+// User-facing !remind command
+client.on("message", async ({ info, message }) => {
+  if (info.isFromMe) return;
+
+  const text =
+    (message.conversation as string) ??
+    (message.extendedTextMessage as { text?: string } | undefined)?.text;
+  if (!text?.startsWith("!remind")) return;
+
+  const match = text.match(/^!remind\s+(\d+)(m|h|s)\s+(.+)$/);
+  if (!match) {
+    await client.sendMessage(info.chat, {
+      conversation: "Usage: !remind <number><m|h|s> <message>\nExample: !remind 30m Take a break",
+    });
+    return;
+  }
+
+  const [, amount, unit, reminder] = match;
+  const multiplier = { s: 1000, m: 60_000, h: 3_600_000 }[unit]!;
+  const delayMs = parseInt(amount) * multiplier;
+
+  setTimeout(async () => {
+    await client.sendRawMessage(info.chat, {
+      extendedTextMessage: {
+        text: `Reminder: ${reminder}`,
+        contextInfo: {
+          mentionedJid: [info.sender],
+        },
+      },
+    });
+  }, delayMs);
+
+  await client.sendMessage(info.chat, {
+    conversation: `I'll remind you in ${amount}${unit}: "${reminder}"`,
+  });
+});
+
+async function main() {
+  const { jid } = await client.init();
+  if (!jid) {
+    console.error("Not paired!");
+    process.exit(1);
+  }
+  await client.connect();
+  await client.sendPresence("available");
+  console.log("Scheduler bot is online!");
+
+  process.on("SIGINT", async () => {
+    await client.sendPresence("unavailable");
+    await client.disconnect();
+    client.close();
+    process.exit(0);
+  });
+}
+
+main().catch(console.error);
+```
+
+## Errores Comunes
+
+:::warning Las programaciones en memoria se pierden al reiniciar
+Las programaciones de `setTimeout` y `node-cron` viven en memoria. Si el proceso se reinicia, los recordatorios pendientes se pierden. Para producción, persiste las programaciones en una base de datos y recárgalas al iniciar.
+:::
+
+:::warning Zonas horarias
+`node-cron` usa la zona horaria del servidor por defecto. Configúrala explícitamente con la opción `timezone` si tus usuarios están en diferentes zonas horarias: `cron.schedule("0 9 * * *", fn, { timezone: "America/Sao_Paulo" })`.
+:::
+
+:::warning Límites de tasa
+Si un cron job envía a muchos destinatarios, espacia los envíos. Consulta [Límites de Tasa](/docs/rate-limiting).
+:::
+
+<RelatedGuides slugs={["send-notifications", "automate-group-messages", "build-a-bot"]} />

--- a/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/schedule-messages.md
+++ b/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/schedule-messages.md
@@ -16,14 +16,14 @@ import {RelatedGuides} from '@site/src/components/RelatedGuides';
     {JSON.stringify({
       "@context": "https://schema.org",
       "@type": "HowTo",
-      "name": "How to Schedule WhatsApp Messages with Node.js",
-      "description": "Schedule WhatsApp messages to send at a specific time with Node.js — delayed sends, recurring reminders, and cron-based scheduling using whatsmeow-node.",
+      "name": "Cómo Programar Mensajes de WhatsApp con Node.js",
+      "description": "Programa mensajes de WhatsApp para enviar a una hora específica con Node.js — envíos diferidos, recordatorios recurrentes y programación con cron usando whatsmeow-node.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/schedule-messages.png",
       "step": [
-        {"@type": "HowToStep", "name": "Send a Delayed Message", "text": "Use setTimeout to send a message after a delay."},
-        {"@type": "HowToStep", "name": "Schedule at a Specific Time", "text": "Calculate the delay from now until the target time and use setTimeout."},
-        {"@type": "HowToStep", "name": "Set Up Recurring Messages", "text": "Use node-cron to send messages on a cron schedule — daily reminders, weekly reports."},
-        {"@type": "HowToStep", "name": "Build a User-Facing Scheduler", "text": "Let users schedule messages via WhatsApp commands like !remind 30m Take a break."}
+        {"@type": "HowToStep", "name": "Enviar un mensaje diferido", "text": "Usa setTimeout para enviar un mensaje después de un delay."},
+        {"@type": "HowToStep", "name": "Programar a una hora específica", "text": "Calcula el delay desde ahora hasta la hora objetivo y usa setTimeout."},
+        {"@type": "HowToStep", "name": "Configurar mensajes recurrentes", "text": "Usa node-cron para enviar mensajes con un horario cron — recordatorios diarios, reportes semanales."},
+        {"@type": "HowToStep", "name": "Crear un programador para usuarios", "text": "Permite que los usuarios programen mensajes vía comandos de WhatsApp como !remind 30m Tomar un descanso."}
       ]
     })}
   </script>
@@ -31,8 +31,8 @@ import {RelatedGuides} from '@site/src/components/RelatedGuides';
     {JSON.stringify({
       "@context": "https://schema.org",
       "@type": "Article",
-      "headline": "How to Schedule WhatsApp Messages with Node.js",
-      "description": "Schedule WhatsApp messages to send at a specific time with Node.js — delayed sends, recurring reminders, and cron-based scheduling using whatsmeow-node.",
+      "headline": "Cómo Programar Mensajes de WhatsApp con Node.js",
+      "description": "Programa mensajes de WhatsApp para enviar a una hora específica con Node.js — envíos diferidos, recordatorios recurrentes y programación con cron usando whatsmeow-node.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/schedule-messages.png",
       "author": {"@type": "Organization", "name": "whatsmeow-node", "url": "https://nicastelo.github.io/whatsmeow-node/"},
       "publisher": {"@type": "Organization", "name": "whatsmeow-node", "logo": {"@type": "ImageObject", "url": "https://nicastelo.github.io/whatsmeow-node/img/image.png"}}

--- a/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/send-messages-typescript.md
+++ b/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/send-messages-typescript.md
@@ -1,0 +1,295 @@
+---
+title: "Cómo Enviar Mensajes de WhatsApp desde TypeScript"
+sidebar_label: Enviar Mensajes (TypeScript)
+sidebar_position: 9
+description: "Envía mensajes de WhatsApp desde TypeScript con tipado completo — texto, respuestas, menciones, multimedia, encuestas y reacciones usando whatsmeow-node."
+keywords: [enviar mensaje whatsapp typescript, whatsapp api typescript, whatsapp bot typescript, enviar texto whatsapp nodejs, whatsapp typescript librería]
+---
+
+import Head from '@docusaurus/Head';
+import {RelatedGuides} from '@site/src/components/RelatedGuides';
+
+<Head>
+  <meta property="og:image" content="https://nicastelo.github.io/whatsmeow-node/img/guides/es/send-messages-typescript.png" />
+  <meta name="twitter:image" content="https://nicastelo.github.io/whatsmeow-node/img/guides/es/send-messages-typescript.png" />
+  <script type="application/ld+json">
+    {JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "HowTo",
+      "name": "How to Send WhatsApp Messages from TypeScript",
+      "description": "Send WhatsApp messages from TypeScript with full type safety — text, replies, mentions, media, polls, and reactions using whatsmeow-node.",
+      "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/send-messages-typescript.png",
+      "step": [
+        {"@type": "HowToStep", "name": "Set Up the Client", "text": "Install whatsmeow-node and create a client with createClient(). Pair via QR code on first run."},
+        {"@type": "HowToStep", "name": "Send a Text Message", "text": "Use sendMessage(jid, { conversation: text }) for simple messages."},
+        {"@type": "HowToStep", "name": "Reply with Quotes and Mentions", "text": "Use sendRawMessage with extendedTextMessage and contextInfo for quoted replies and @mentions."},
+        {"@type": "HowToStep", "name": "Send Media Messages", "text": "Upload files with uploadMedia(), then send with sendRawMessage using the returned media metadata."},
+        {"@type": "HowToStep", "name": "React, Edit, and Delete", "text": "Use sendReaction(), editMessage(), and revokeMessage() to interact with sent messages."}
+      ]
+    })}
+  </script>
+  <script type="application/ld+json">
+    {JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "Article",
+      "headline": "How to Send WhatsApp Messages from TypeScript",
+      "description": "Send WhatsApp messages from TypeScript with full type safety — text, replies, mentions, media, polls, and reactions using whatsmeow-node.",
+      "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/send-messages-typescript.png",
+      "author": {"@type": "Organization", "name": "whatsmeow-node", "url": "https://nicastelo.github.io/whatsmeow-node/"},
+      "publisher": {"@type": "Organization", "name": "whatsmeow-node", "logo": {"@type": "ImageObject", "url": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/send-messages-typescript.png"}}
+    })}
+  </script>
+</Head>
+
+![Cómo Enviar Mensajes de WhatsApp desde TypeScript](/img/guides/es/send-messages-typescript.png)
+![Cómo Enviar Mensajes de WhatsApp desde TypeScript](/img/guides/es/send-messages-typescript-light.png)
+
+# Cómo Enviar Mensajes de WhatsApp desde TypeScript
+
+whatsmeow-node te da métodos async tipados para cada tipo de mensaje de WhatsApp — texto, respuestas, menciones, multimedia, encuestas y reacciones. Esta guía cubre cada uno con ejemplos en TypeScript.
+
+## Requisitos Previos
+
+- whatsmeow-node instalado ([Guía de instalación](/docs/installation))
+- Una sesión vinculada ([Cómo Vincular WhatsApp](pair-whatsapp))
+
+## Configurar el Cliente
+
+```typescript
+import { createClient } from "@whatsmeow-node/whatsmeow-node";
+
+const client = createClient({ store: "session.db" });
+
+async function main() {
+  const { jid: myJid } = await client.init();
+  if (!myJid) {
+    console.error("Not paired — run the pairing flow first");
+    process.exit(1);
+  }
+  await client.connect();
+  await client.waitForConnection();
+
+  const recipient = "5512345678@s.whatsapp.net";
+
+  // ... send messages here
+}
+
+main().catch(console.error);
+```
+
+## Enviar un Mensaje de Texto
+
+La forma más simple — pasa un string `conversation`:
+
+```typescript
+const resp = await client.sendMessage(recipient, {
+  conversation: "Hello from TypeScript!",
+});
+
+console.log(`Sent with ID: ${resp.id}`);
+```
+
+`sendMessage` es el método de alto nivel. Recibe un JID y un objeto `MessageContent`, y devuelve un `SendResponse` con el `id` y `timestamp` del mensaje.
+
+## Responder con Cita
+
+Para mostrar el mensaje original en una burbuja de cita, usa `sendRawMessage` con `contextInfo`:
+
+```typescript
+// Assume we received a message and have its info
+client.on("message", async ({ info, message }) => {
+  if (info.isFromMe) return;
+
+  const text =
+    (message.conversation as string) ??
+    (message.extendedTextMessage as { text?: string } | undefined)?.text;
+  if (!text) return;
+
+  await client.sendRawMessage(info.chat, {
+    extendedTextMessage: {
+      text: `You said: "${text}"`,
+      contextInfo: {
+        stanzaId: info.id,
+        participant: info.sender,
+        quotedMessage: { conversation: text },
+      },
+    },
+  });
+});
+```
+
+## @Mencionar Usuarios
+
+Incluye los JID en `mentionedJid` y usa `@<número>` en el texto:
+
+```typescript
+await client.sendRawMessage(groupJid, {
+  extendedTextMessage: {
+    text: `Hey @${memberJid.split("@")[0]}, check this out!`,
+    contextInfo: {
+      mentionedJid: [memberJid],
+    },
+  },
+});
+```
+
+Para mencionar a todos en un grupo:
+
+```typescript
+const group = await client.getGroupInfo(groupJid);
+const jids = group.participants.map((p) => p.jid);
+const mentions = jids.map((j) => `@${j.split("@")[0]}`).join(" ");
+
+await client.sendRawMessage(groupJid, {
+  extendedTextMessage: {
+    text: `Attention: ${mentions}`,
+    contextInfo: { mentionedJid: jids },
+  },
+});
+```
+
+## Enviar Multimedia
+
+Primero sube el archivo, luego envía los metadatos con un mensaje raw:
+
+```typescript
+// Upload an image
+const media = await client.uploadMedia("/path/to/photo.jpg", "image");
+
+await client.sendRawMessage(recipient, {
+  imageMessage: {
+    URL: media.URL,
+    directPath: media.directPath,
+    mediaKey: media.mediaKey,
+    fileEncSHA256: media.fileEncSHA256,
+    fileSHA256: media.fileSHA256,
+    fileLength: String(media.fileLength),
+    mimetype: "image/jpeg",
+    caption: "Check this out!",
+  },
+});
+```
+
+Otros tipos de multimedia siguen el mismo patrón — `videoMessage`, `audioMessage`, `documentMessage`, `stickerMessage`.
+
+:::warning Casing de campos proto
+Los campos de respuesta de upload usan el casing exacto de protobuf: `URL`, `fileSHA256`, `fileEncSHA256` — **no** `url`, `fileSha256`. Un casing incorrecto falla silenciosamente.
+:::
+
+## Enviar una Encuesta
+
+```typescript
+const resp = await client.sendPollCreation(
+  groupJid,
+  "Where should we eat?",       // question
+  ["Pizza", "Sushi", "Tacos"],   // options
+  1,                              // max selectable
+);
+```
+
+## Reaccionar a un Mensaje
+
+```typescript
+// Add a reaction
+await client.sendReaction(chat, senderJid, messageId, "🔥");
+
+// Remove a reaction (empty string)
+await client.sendReaction(chat, senderJid, messageId, "");
+```
+
+## Editar un Mensaje Enviado
+
+```typescript
+const sent = await client.sendMessage(recipient, {
+  conversation: "Hello!",
+});
+
+// Edit it — only works on your own messages
+await client.editMessage(recipient, sent.id, {
+  conversation: "Hello! (edited)",
+});
+```
+
+## Eliminar un Mensaje
+
+```typescript
+// Revoke for everyone — only your own messages, within the time limit
+await client.revokeMessage(chat, myJid, sent.id);
+```
+
+## Marcar como Leído
+
+```typescript
+await client.markRead([info.id], info.chat, info.sender);
+```
+
+## Ejemplo Completo
+
+Un bot que repite los mensajes de texto como respuestas citadas:
+
+```typescript
+import { createClient } from "@whatsmeow-node/whatsmeow-node";
+import qrcode from "qrcode-terminal";
+
+const client = createClient({ store: "session.db" });
+
+client.on("error", (err) => console.error("Error:", err));
+
+client.on("message", async ({ info, message }) => {
+  if (info.isFromMe) return;
+
+  const text =
+    (message.conversation as string) ??
+    (message.extendedTextMessage as { text?: string } | undefined)?.text;
+  if (!text) return;
+
+  await client.markRead([info.id], info.chat, info.sender);
+  await client.sendChatPresence(info.chat, "composing");
+
+  await client.sendRawMessage(info.chat, {
+    extendedTextMessage: {
+      text: `Echo: ${text}`,
+      contextInfo: {
+        stanzaId: info.id,
+        participant: info.sender,
+        quotedMessage: { conversation: text },
+      },
+    },
+  });
+});
+
+async function main() {
+  const { jid } = await client.init();
+  if (!jid) {
+    client.on("qr", ({ code }) => qrcode.generate(code, { small: true }));
+    await client.getQRChannel();
+  }
+  await client.connect();
+  console.log("Listening for messages...");
+
+  process.on("SIGINT", async () => {
+    await client.sendPresence("unavailable");
+    await client.disconnect();
+    client.close();
+    process.exit(0);
+  });
+}
+
+main().catch(console.error);
+```
+
+## Errores Comunes
+
+:::warning `sendMessage` vs `sendRawMessage`
+`sendMessage` es para texto simple. Para cualquier cosa estructurada (citas, menciones, multimedia), usa `sendRawMessage` con la forma completa del protobuf.
+:::
+
+:::warning Los mensajes de grupo van a `info.chat`
+En grupos, siempre envía a `info.chat` (el JID del grupo), no a `info.sender` (el individuo). Enviar a `info.sender` inicia una conversación privada.
+:::
+
+:::warning Límites de tasa
+WhatsApp limita la tasa de envío. Espacia los mensajes, especialmente en grupos. Consulta [Límites de Tasa](/docs/rate-limiting) para más detalles.
+:::
+
+<RelatedGuides slugs={["build-a-bot", "automate-group-messages", "send-stickers", "send-notifications"]} />

--- a/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/send-messages-typescript.md
+++ b/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/send-messages-typescript.md
@@ -16,15 +16,15 @@ import {RelatedGuides} from '@site/src/components/RelatedGuides';
     {JSON.stringify({
       "@context": "https://schema.org",
       "@type": "HowTo",
-      "name": "How to Send WhatsApp Messages from TypeScript",
-      "description": "Send WhatsApp messages from TypeScript with full type safety — text, replies, mentions, media, polls, and reactions using whatsmeow-node.",
+      "name": "Cómo Enviar Mensajes de WhatsApp desde TypeScript",
+      "description": "Envía mensajes de WhatsApp desde TypeScript con tipado completo — texto, respuestas, menciones, multimedia, encuestas y reacciones usando whatsmeow-node.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/send-messages-typescript.png",
       "step": [
-        {"@type": "HowToStep", "name": "Set Up the Client", "text": "Install whatsmeow-node and create a client with createClient(). Pair via QR code on first run."},
-        {"@type": "HowToStep", "name": "Send a Text Message", "text": "Use sendMessage(jid, { conversation: text }) for simple messages."},
-        {"@type": "HowToStep", "name": "Reply with Quotes and Mentions", "text": "Use sendRawMessage with extendedTextMessage and contextInfo for quoted replies and @mentions."},
-        {"@type": "HowToStep", "name": "Send Media Messages", "text": "Upload files with uploadMedia(), then send with sendRawMessage using the returned media metadata."},
-        {"@type": "HowToStep", "name": "React, Edit, and Delete", "text": "Use sendReaction(), editMessage(), and revokeMessage() to interact with sent messages."}
+        {"@type": "HowToStep", "name": "Configurar el cliente", "text": "Instala whatsmeow-node y crea un cliente con createClient(). Vincula vía QR code en la primera ejecución."},
+        {"@type": "HowToStep", "name": "Enviar un mensaje de texto", "text": "Usa sendMessage(jid, { conversation: text }) para mensajes simples."},
+        {"@type": "HowToStep", "name": "Responder con citas y menciones", "text": "Usa sendRawMessage con extendedTextMessage y contextInfo para respuestas citadas y @menciones."},
+        {"@type": "HowToStep", "name": "Enviar mensajes multimedia", "text": "Sube archivos con uploadMedia(), luego envía con sendRawMessage usando los metadatos de multimedia devueltos."},
+        {"@type": "HowToStep", "name": "Reaccionar, editar y eliminar", "text": "Usa sendReaction(), editMessage() y revokeMessage() para interactuar con los mensajes enviados."}
       ]
     })}
   </script>
@@ -32,8 +32,8 @@ import {RelatedGuides} from '@site/src/components/RelatedGuides';
     {JSON.stringify({
       "@context": "https://schema.org",
       "@type": "Article",
-      "headline": "How to Send WhatsApp Messages from TypeScript",
-      "description": "Send WhatsApp messages from TypeScript with full type safety — text, replies, mentions, media, polls, and reactions using whatsmeow-node.",
+      "headline": "Cómo Enviar Mensajes de WhatsApp desde TypeScript",
+      "description": "Envía mensajes de WhatsApp desde TypeScript con tipado completo — texto, respuestas, menciones, multimedia, encuestas y reacciones usando whatsmeow-node.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/send-messages-typescript.png",
       "author": {"@type": "Organization", "name": "whatsmeow-node", "url": "https://nicastelo.github.io/whatsmeow-node/"},
       "publisher": {"@type": "Organization", "name": "whatsmeow-node", "logo": {"@type": "ImageObject", "url": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/send-messages-typescript.png"}}

--- a/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/send-notifications.md
+++ b/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/send-notifications.md
@@ -1,0 +1,271 @@
+---
+title: "Cómo Enviar Notificaciones de WhatsApp desde Node.js"
+sidebar_label: Enviar Notificaciones
+sidebar_position: 17
+description: "Envía notificaciones, alertas y recordatorios de WhatsApp desde Node.js — actualizaciones de pedidos, recordatorios de citas, alertas del sistema y más usando whatsmeow-node."
+keywords: [enviar notificación whatsapp nodejs, whatsapp notificación api, bot alertas whatsapp, bot recordatorios whatsapp, enviar mensaje whatsapp programáticamente]
+---
+
+import Head from '@docusaurus/Head';
+import {RelatedGuides} from '@site/src/components/RelatedGuides';
+
+<Head>
+  <meta property="og:image" content="https://nicastelo.github.io/whatsmeow-node/img/guides/es/send-notifications.png" />
+  <meta name="twitter:image" content="https://nicastelo.github.io/whatsmeow-node/img/guides/es/send-notifications.png" />
+  <script type="application/ld+json">
+    {JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "HowTo",
+      "name": "How to Send WhatsApp Notifications from Node.js",
+      "description": "Send WhatsApp notifications, alerts, and reminders from Node.js — order updates, appointment reminders, system alerts, and more using whatsmeow-node.",
+      "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/send-notifications.png",
+      "step": [
+        {"@type": "HowToStep", "name": "Set Up the Client", "text": "Create a WhatsmeowClient, init, and connect. The client stays connected in the background."},
+        {"@type": "HowToStep", "name": "Send a Notification", "text": "Call sendMessage() with the recipient JID and a conversation message."},
+        {"@type": "HowToStep", "name": "Trigger from External Events", "text": "Call sendMessage from an HTTP endpoint, database trigger, or cron job."},
+        {"@type": "HowToStep", "name": "Send to Multiple Recipients", "text": "Iterate over a list of JIDs with a delay between sends to avoid rate limiting."}
+      ]
+    })}
+  </script>
+  <script type="application/ld+json">
+    {JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "Article",
+      "headline": "How to Send WhatsApp Notifications from Node.js",
+      "description": "Send WhatsApp notifications, alerts, and reminders from Node.js — order updates, appointment reminders, system alerts, and more using whatsmeow-node.",
+      "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/send-notifications.png",
+      "author": {"@type": "Organization", "name": "whatsmeow-node", "url": "https://nicastelo.github.io/whatsmeow-node/"},
+      "publisher": {"@type": "Organization", "name": "whatsmeow-node", "logo": {"@type": "ImageObject", "url": "https://nicastelo.github.io/whatsmeow-node/img/image.png"}}
+    })}
+  </script>
+</Head>
+
+![Cómo Enviar Notificaciones de WhatsApp desde Node.js](/img/guides/es/send-notifications.png)
+![Cómo Enviar Notificaciones de WhatsApp desde Node.js](/img/guides/es/send-notifications-light.png)
+
+# Cómo Enviar Notificaciones de WhatsApp desde Node.js
+
+Envía alertas, recordatorios y actualizaciones a WhatsApp desde cualquier app Node.js. whatsmeow-node se mantiene conectado en segundo plano — solo llamas a `sendMessage()` cuando necesites notificar a alguien.
+
+## Requisitos Previos
+
+- Una sesión vinculada de whatsmeow-node ([Cómo Vincular](pair-whatsapp))
+- El número de teléfono del destinatario (como JID: `5512345678@s.whatsapp.net`)
+
+## Paso 1: Configurar una Conexión Persistente
+
+```typescript
+import { createClient } from "@whatsmeow-node/whatsmeow-node";
+
+const client = createClient({ store: "session.db" });
+
+async function start() {
+  const { jid } = await client.init();
+  if (!jid) {
+    console.error("Not paired! See: How to Pair WhatsApp");
+    process.exit(1);
+  }
+  await client.connect();
+  await client.sendPresence("available");
+  console.log("Notification service is ready");
+}
+
+start().catch(console.error);
+```
+
+El cliente se mantiene conectado y listo para enviar mensajes en cualquier momento.
+
+## Paso 2: Enviar una Notificación
+
+```typescript
+async function notify(phone: string, message: string) {
+  const jid = `${phone}@s.whatsapp.net`;
+  await client.sendMessage(jid, { conversation: message });
+}
+
+// Example: order update
+await notify("5512345678", "Your order #1234 has shipped! Track it at https://example.com/track/1234");
+```
+
+## Paso 3: Disparar desde un Endpoint HTTP
+
+Envuelve la notificación en una ruta de Express para que otros servicios puedan activarla:
+
+```typescript
+import express from "express";
+
+const app = express();
+app.use(express.json());
+
+app.post("/notify", async (req, res) => {
+  const { phone, message } = req.body;
+
+  if (!phone || !message) {
+    return res.status(400).json({ error: "phone and message are required" });
+  }
+
+  try {
+    const jid = `${phone}@s.whatsapp.net`;
+    const resp = await client.sendMessage(jid, { conversation: message });
+    res.json({ sent: true, id: resp.id });
+  } catch (err) {
+    res.status(500).json({ error: "Failed to send" });
+  }
+});
+
+app.listen(3000, () => console.log("Notification API on :3000"));
+```
+
+Ahora cualquier servicio puede enviar una notificación:
+
+```bash
+curl -X POST http://localhost:3000/notify \
+  -H "Content-Type: application/json" \
+  -d '{"phone": "5512345678", "message": "Your appointment is in 1 hour"}'
+```
+
+## Paso 4: Enviar a Múltiples Destinatarios
+
+```typescript
+async function broadcast(phones: string[], message: string) {
+  for (const phone of phones) {
+    const jid = `${phone}@s.whatsapp.net`;
+    await client.sendMessage(jid, { conversation: message });
+
+    // Wait between sends to avoid rate limiting
+    await new Promise((r) => setTimeout(r, 2000));
+  }
+}
+
+await broadcast(
+  ["5512345678", "5598765432", "5511223344"],
+  "Reminder: team meeting at 3 PM today",
+);
+```
+
+:::warning Límites de tasa
+WhatsApp limita la tasa de envío. Espacia los mensajes de 1 a 3 segundos para envíos masivos. Enviar demasiado rápido puede hacer que tu cuenta sea restringida temporalmente. Consulta [Límites de Tasa](/docs/rate-limiting).
+:::
+
+## Patrones de Notificación
+
+### Recordatorio de cita
+
+```typescript
+await notify(phone, `Reminder: your appointment with Dr. Smith is tomorrow at 10:00 AM.
+
+Reply CONFIRM to confirm or CANCEL to cancel.`);
+```
+
+### Actualización de pedido
+
+```typescript
+await notify(phone, `Order #${orderId} update: ${status}
+
+${status === "shipped" ? `Track: ${trackingUrl}` : ""}`);
+```
+
+### Alerta del sistema
+
+```typescript
+await notify(adminPhone, `⚠ Server alert: CPU usage at ${cpuPercent}% on ${hostname}`);
+```
+
+### Notificación a grupo
+
+```typescript
+// Send to a group instead of an individual
+const groupJid = "120363XXXXX@g.us";
+await client.sendMessage(groupJid, {
+  conversation: "Deploy complete: v2.1.0 is live",
+});
+```
+
+## Ejemplo Completo
+
+Un servicio de notificaciones con API HTTP:
+
+```typescript
+import { createClient } from "@whatsmeow-node/whatsmeow-node";
+import express from "express";
+
+const client = createClient({ store: "session.db" });
+const app = express();
+app.use(express.json());
+
+app.post("/notify", async (req, res) => {
+  const { phone, message } = req.body;
+  if (!phone || !message) {
+    return res.status(400).json({ error: "phone and message are required" });
+  }
+
+  try {
+    const jid = `${phone}@s.whatsapp.net`;
+    const resp = await client.sendMessage(jid, { conversation: message });
+    res.json({ sent: true, id: resp.id });
+  } catch (err) {
+    console.error("Send failed:", err);
+    res.status(500).json({ error: "Failed to send" });
+  }
+});
+
+app.post("/broadcast", async (req, res) => {
+  const { phones, message } = req.body;
+  if (!phones?.length || !message) {
+    return res.status(400).json({ error: "phones[] and message are required" });
+  }
+
+  // Send in background
+  (async () => {
+    for (const phone of phones) {
+      try {
+        const jid = `${phone}@s.whatsapp.net`;
+        await client.sendMessage(jid, { conversation: message });
+      } catch (err) {
+        console.error(`Failed to send to ${phone}:`, err);
+      }
+      await new Promise((r) => setTimeout(r, 2000));
+    }
+    console.log(`Broadcast complete: ${phones.length} recipients`);
+  })();
+
+  res.json({ queued: true, count: phones.length });
+});
+
+async function main() {
+  const { jid } = await client.init();
+  if (!jid) {
+    console.error("Not paired!");
+    process.exit(1);
+  }
+  await client.connect();
+  await client.sendPresence("available");
+
+  app.listen(3000, () => console.log("Notification API on :3000"));
+
+  process.on("SIGINT", async () => {
+    await client.sendPresence("unavailable");
+    await client.disconnect();
+    client.close();
+    process.exit(0);
+  });
+}
+
+main().catch(console.error);
+```
+
+## Errores Comunes
+
+:::warning No hagas spam
+Enviar mensajes masivos no solicitados viola los Términos de Servicio de WhatsApp y hará que tu cuenta sea baneada. Solo envía notificaciones a usuarios que hayan dado su consentimiento.
+:::
+
+:::warning Límites de tasa
+Espacia los envíos con un delay de 1-3 segundos. Consulta [Límites de Tasa](/docs/rate-limiting) para más detalles.
+:::
+
+:::warning Mantén la conexión activa
+El cliente debe permanecer conectado para enviar mensajes. Si el proceso termina, tendrás que reconectar. Para producción, usa un gestor de procesos como PM2 o ejecútalo como servicio de systemd.
+:::
+
+<RelatedGuides slugs={["schedule-messages", "automate-group-messages", "build-a-bot"]} />

--- a/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/send-notifications.md
+++ b/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/send-notifications.md
@@ -16,14 +16,14 @@ import {RelatedGuides} from '@site/src/components/RelatedGuides';
     {JSON.stringify({
       "@context": "https://schema.org",
       "@type": "HowTo",
-      "name": "How to Send WhatsApp Notifications from Node.js",
-      "description": "Send WhatsApp notifications, alerts, and reminders from Node.js — order updates, appointment reminders, system alerts, and more using whatsmeow-node.",
+      "name": "Cómo Enviar Notificaciones de WhatsApp desde Node.js",
+      "description": "Envía notificaciones, alertas y recordatorios de WhatsApp desde Node.js — actualizaciones de pedidos, recordatorios de citas, alertas del sistema y más usando whatsmeow-node.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/send-notifications.png",
       "step": [
-        {"@type": "HowToStep", "name": "Set Up the Client", "text": "Create a WhatsmeowClient, init, and connect. The client stays connected in the background."},
-        {"@type": "HowToStep", "name": "Send a Notification", "text": "Call sendMessage() with the recipient JID and a conversation message."},
-        {"@type": "HowToStep", "name": "Trigger from External Events", "text": "Call sendMessage from an HTTP endpoint, database trigger, or cron job."},
-        {"@type": "HowToStep", "name": "Send to Multiple Recipients", "text": "Iterate over a list of JIDs with a delay between sends to avoid rate limiting."}
+        {"@type": "HowToStep", "name": "Configurar el cliente", "text": "Crea un WhatsmeowClient, inicializa y conecta. El cliente se mantiene conectado en segundo plano."},
+        {"@type": "HowToStep", "name": "Enviar una notificación", "text": "Llama a sendMessage() con el JID del destinatario y un mensaje de conversación."},
+        {"@type": "HowToStep", "name": "Disparar desde eventos externos", "text": "Llama a sendMessage desde un endpoint HTTP, un trigger de base de datos o un cron job."},
+        {"@type": "HowToStep", "name": "Enviar a múltiples destinatarios", "text": "Itera sobre una lista de JIDs con un delay entre envíos para evitar límites de tasa."}
       ]
     })}
   </script>
@@ -31,8 +31,8 @@ import {RelatedGuides} from '@site/src/components/RelatedGuides';
     {JSON.stringify({
       "@context": "https://schema.org",
       "@type": "Article",
-      "headline": "How to Send WhatsApp Notifications from Node.js",
-      "description": "Send WhatsApp notifications, alerts, and reminders from Node.js — order updates, appointment reminders, system alerts, and more using whatsmeow-node.",
+      "headline": "Cómo Enviar Notificaciones de WhatsApp desde Node.js",
+      "description": "Envía notificaciones, alertas y recordatorios de WhatsApp desde Node.js — actualizaciones de pedidos, recordatorios de citas, alertas del sistema y más usando whatsmeow-node.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/send-notifications.png",
       "author": {"@type": "Organization", "name": "whatsmeow-node", "url": "https://nicastelo.github.io/whatsmeow-node/"},
       "publisher": {"@type": "Organization", "name": "whatsmeow-node", "logo": {"@type": "ImageObject", "url": "https://nicastelo.github.io/whatsmeow-node/img/image.png"}}

--- a/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/send-stickers.md
+++ b/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/send-stickers.md
@@ -19,9 +19,9 @@ import Head from '@docusaurus/Head';
       "description": "Envía y recibe stickers de WhatsApp programáticamente con Node.js — sube archivos WebP, configura dimensiones y descarga stickers entrantes.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/send-stickers.png",
       "step": [
-        {"@type": "HowToStep", "name": "Upload the Sticker File", "text": "Use uploadMedia() with the WebP file path and 'image' media type."},
-        {"@type": "HowToStep", "name": "Send the Sticker Message", "text": "Use sendRawMessage with stickerMessage including width, height (512x512), and mimetype image/webp."},
-        {"@type": "HowToStep", "name": "Download Incoming Stickers", "text": "Listen for messages with stickerMessage and call downloadAny() to save to disk."}
+        {"@type": "HowToStep", "name": "Subir el archivo del sticker", "text": "Usa uploadMedia() con la ruta del archivo WebP y el tipo de multimedia 'image'."},
+        {"@type": "HowToStep", "name": "Enviar el mensaje de sticker", "text": "Usa sendRawMessage con stickerMessage incluyendo width, height (512x512) y mimetype image/webp."},
+        {"@type": "HowToStep", "name": "Descargar stickers entrantes", "text": "Escucha los mensajes con stickerMessage y llama a downloadAny() para guardarlos en disco."}
       ]
     })}
   </script>

--- a/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/typing-indicators.md
+++ b/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/typing-indicators.md
@@ -19,11 +19,11 @@ import Head from '@docusaurus/Head';
       "description": "Muestra indicadores de escritura y grabación en WhatsApp con Node.js — controla el estado de composición, presencia en línea y suscríbete a la escritura de otros.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/typing-indicators.png",
       "step": [
-        {"@type": "HowToStep", "name": "Show typing...", "text": "Call sendChatPresence(chatJid, 'composing') to show the typing indicator."},
-        {"@type": "HowToStep", "name": "Show recording audio...", "text": "Call sendChatPresence(chatJid, 'composing', 'audio') for the recording indicator."},
-        {"@type": "HowToStep", "name": "Clear the Indicator", "text": "Call sendChatPresence(chatJid, 'paused') to stop the indicator without sending a message."},
-        {"@type": "HowToStep", "name": "Set Online/Offline Status", "text": "Call sendPresence('available') before typing indicators work, and 'unavailable' when shutting down."},
-        {"@type": "HowToStep", "name": "Subscribe to Others' Typing", "text": "Call subscribePresence(jid) and listen for presence and chat_presence events."}
+        {"@type": "HowToStep", "name": "Mostrar escribiendo...", "text": "Llama a sendChatPresence(chatJid, 'composing') para mostrar el indicador de escritura."},
+        {"@type": "HowToStep", "name": "Mostrar grabando audio...", "text": "Llama a sendChatPresence(chatJid, 'composing', 'audio') para el indicador de grabación."},
+        {"@type": "HowToStep", "name": "Borrar el indicador", "text": "Llama a sendChatPresence(chatJid, 'paused') para detener el indicador sin enviar un mensaje."},
+        {"@type": "HowToStep", "name": "Establecer estado en línea/desconectado", "text": "Llama a sendPresence('available') antes de que los indicadores de escritura funcionen, y 'unavailable' al apagar."},
+        {"@type": "HowToStep", "name": "Suscribirse a la escritura de otros", "text": "Llama a subscribePresence(jid) y escucha los eventos presence y chat_presence."}
       ]
     })}
   </script>

--- a/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/whatsmeow-in-node.md
+++ b/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/whatsmeow-in-node.md
@@ -16,14 +16,14 @@ import {RelatedGuides} from '@site/src/components/RelatedGuides';
     {JSON.stringify({
       "@context": "https://schema.org",
       "@type": "HowTo",
-      "name": "How to Use whatsmeow in Node.js",
-      "description": "Use whatsmeow from Node.js and TypeScript — install the npm package, connect to WhatsApp, send messages, and handle events without writing Go.",
+      "name": "Cómo Usar whatsmeow en Node.js",
+      "description": "Usa whatsmeow desde Node.js y TypeScript — instala el paquete npm, conéctate a WhatsApp, envía mensajes y maneja eventos sin escribir Go.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/whatsmeow-in-node.png",
       "step": [
-        {"@type": "HowToStep", "name": "Install whatsmeow-node", "text": "Run npm install @whatsmeow-node/whatsmeow-node to get the precompiled Go binary and TypeScript wrapper."},
-        {"@type": "HowToStep", "name": "Create a Client", "text": "Use createClient() with a store path. The Go binary is spawned and managed automatically."},
-        {"@type": "HowToStep", "name": "Connect to WhatsApp", "text": "Call init() to check for an existing session, then connect(). Pair via QR code on first run."},
-        {"@type": "HowToStep", "name": "Send Messages and Handle Events", "text": "Use typed async methods like sendMessage() and listen for events like message, connected, and group:info."}
+        {"@type": "HowToStep", "name": "Instalar whatsmeow-node", "text": "Ejecuta npm install @whatsmeow-node/whatsmeow-node para obtener el binario Go precompilado y el wrapper de TypeScript."},
+        {"@type": "HowToStep", "name": "Crear un cliente", "text": "Usa createClient() con una ruta de almacén. El binario Go se lanza y gestiona automáticamente."},
+        {"@type": "HowToStep", "name": "Conectar a WhatsApp", "text": "Llama a init() para verificar si hay una sesión existente, luego connect(). Vincula vía QR code en la primera ejecución."},
+        {"@type": "HowToStep", "name": "Enviar mensajes y manejar eventos", "text": "Usa métodos async tipados como sendMessage() y escucha eventos como message, connected y group:info."}
       ]
     })}
   </script>
@@ -31,8 +31,8 @@ import {RelatedGuides} from '@site/src/components/RelatedGuides';
     {JSON.stringify({
       "@context": "https://schema.org",
       "@type": "Article",
-      "headline": "How to Use whatsmeow in Node.js",
-      "description": "Use whatsmeow from Node.js and TypeScript — install the npm package, connect to WhatsApp, send messages, and handle events without writing Go.",
+      "headline": "Cómo Usar whatsmeow en Node.js",
+      "description": "Usa whatsmeow desde Node.js y TypeScript — instala el paquete npm, conéctate a WhatsApp, envía mensajes y maneja eventos sin escribir Go.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/whatsmeow-in-node.png",
       "author": {"@type": "Organization", "name": "whatsmeow-node", "url": "https://nicastelo.github.io/whatsmeow-node/"},
       "publisher": {"@type": "Organization", "name": "whatsmeow-node", "logo": {"@type": "ImageObject", "url": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/whatsmeow-in-node.png"}}

--- a/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/whatsmeow-in-node.md
+++ b/docs-site/i18n/es/docusaurus-plugin-content-docs/current/guides/whatsmeow-in-node.md
@@ -1,0 +1,221 @@
+---
+title: "Cómo Usar whatsmeow en Node.js"
+sidebar_label: whatsmeow en Node.js
+sidebar_position: 8
+description: "Usa whatsmeow desde Node.js y TypeScript — instala el paquete npm, conéctate a WhatsApp, envía mensajes y maneja eventos sin escribir Go."
+keywords: [whatsmeow nodejs, whatsmeow node, whatsmeow typescript, whatsmeow npm, usar whatsmeow en javascript]
+---
+
+import Head from '@docusaurus/Head';
+import {RelatedGuides} from '@site/src/components/RelatedGuides';
+
+<Head>
+  <meta property="og:image" content="https://nicastelo.github.io/whatsmeow-node/img/guides/es/whatsmeow-in-node.png" />
+  <meta name="twitter:image" content="https://nicastelo.github.io/whatsmeow-node/img/guides/es/whatsmeow-in-node.png" />
+  <script type="application/ld+json">
+    {JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "HowTo",
+      "name": "How to Use whatsmeow in Node.js",
+      "description": "Use whatsmeow from Node.js and TypeScript — install the npm package, connect to WhatsApp, send messages, and handle events without writing Go.",
+      "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/whatsmeow-in-node.png",
+      "step": [
+        {"@type": "HowToStep", "name": "Install whatsmeow-node", "text": "Run npm install @whatsmeow-node/whatsmeow-node to get the precompiled Go binary and TypeScript wrapper."},
+        {"@type": "HowToStep", "name": "Create a Client", "text": "Use createClient() with a store path. The Go binary is spawned and managed automatically."},
+        {"@type": "HowToStep", "name": "Connect to WhatsApp", "text": "Call init() to check for an existing session, then connect(). Pair via QR code on first run."},
+        {"@type": "HowToStep", "name": "Send Messages and Handle Events", "text": "Use typed async methods like sendMessage() and listen for events like message, connected, and group:info."}
+      ]
+    })}
+  </script>
+  <script type="application/ld+json">
+    {JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "Article",
+      "headline": "How to Use whatsmeow in Node.js",
+      "description": "Use whatsmeow from Node.js and TypeScript — install the npm package, connect to WhatsApp, send messages, and handle events without writing Go.",
+      "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/whatsmeow-in-node.png",
+      "author": {"@type": "Organization", "name": "whatsmeow-node", "url": "https://nicastelo.github.io/whatsmeow-node/"},
+      "publisher": {"@type": "Organization", "name": "whatsmeow-node", "logo": {"@type": "ImageObject", "url": "https://nicastelo.github.io/whatsmeow-node/img/guides/es/whatsmeow-in-node.png"}}
+    })}
+  </script>
+</Head>
+
+![Cómo Usar whatsmeow en Node.js](/img/guides/es/whatsmeow-in-node.png)
+![Cómo Usar whatsmeow en Node.js](/img/guides/es/whatsmeow-in-node-light.png)
+
+# Cómo Usar whatsmeow en Node.js
+
+[whatsmeow](https://github.com/tulir/whatsmeow) es la biblioteca Go más probada en batalla para el protocolo multi-dispositivo de WhatsApp — es el motor del [puente Mautrix WhatsApp](https://github.com/mautrix/whatsapp) usado por miles de servidores Matrix 24/7. whatsmeow-node la trae a Node.js con métodos async tipados y una API basada en eventos, sin necesidad de configurar Go.
+
+## Cómo Funciona
+
+whatsmeow-node incluye un binario Go precompilado para tu plataforma (macOS, Linux, Windows). Cuando llamas a `createClient()`, lanza ese binario y se comunica por IPC JSON-line a través de stdin/stdout:
+
+```
+Node.js (TypeScript) → stdin JSON → Go binary (whatsmeow) → WhatsApp
+                     ← stdout JSON ←
+```
+
+Nunca interactúas con el binario directamente. Cada método de whatsmeow está expuesto como una función async tipada en el cliente.
+
+## Paso 1: Instalar
+
+```bash
+npm install @whatsmeow-node/whatsmeow-node
+```
+
+El binario correcto para tu SO y arquitectura se instala automáticamente como dependencia opcional.
+
+:::info
+Plataformas soportadas: macOS (arm64, x64), Linux (arm64, x64), Windows (x64). Consulta [Instalación](/docs/installation) para más detalles.
+:::
+
+## Paso 2: Crear un Cliente
+
+```typescript
+import { createClient } from "@whatsmeow-node/whatsmeow-node";
+
+const client = createClient({ store: "session.db" });
+
+client.on("error", (err) => {
+  console.error("Error:", err);
+});
+```
+
+`store` es donde whatsmeow persiste la sesión. Usa una ruta de archivo para SQLite (desarrollo) o una URI de PostgreSQL para producción.
+
+## Paso 3: Conectar a WhatsApp
+
+```typescript
+import qrcode from "qrcode-terminal";
+
+async function main() {
+  const { jid } = await client.init();
+
+  if (jid) {
+    // Ya está vinculado — reconectar
+    console.log(`Resuming session for ${jid}`);
+    await client.connect();
+  } else {
+    // Primera ejecución — vincular vía QR code
+    client.on("qr", ({ code }) => qrcode.generate(code, { small: true }));
+    await client.getQRChannel();
+    await client.connect();
+  }
+}
+
+main().catch(console.error);
+```
+
+Después de escanear el QR code una vez, la sesión se almacena y las ejecuciones siguientes van directo a `connect()`.
+
+## Paso 4: Enviar Mensajes y Manejar Eventos
+
+```typescript
+// Send a text message
+const jid = "5512345678@s.whatsapp.net";
+await client.sendMessage(jid, { conversation: "Hello from whatsmeow!" });
+
+// Listen for incoming messages
+client.on("message", async ({ info, message }) => {
+  if (info.isFromMe) return;
+
+  const text =
+    (message.conversation as string) ??
+    (message.extendedTextMessage as { text?: string } | undefined)?.text;
+
+  if (text) {
+    console.log(`${info.pushName}: ${text}`);
+  }
+});
+
+// Listen for group events
+client.on("group:info", (event) => {
+  if (event.join) console.log(`${event.join.join(", ")} joined ${event.jid}`);
+});
+```
+
+## Qué Está Disponible
+
+whatsmeow-node envuelve más de 100 métodos de whatsmeow. Las áreas principales:
+
+| Categoría | Métodos |
+|----------|---------|
+| **Mensajería** | `sendMessage`, `sendRawMessage`, `editMessage`, `revokeMessage`, `sendReaction`, `markRead` |
+| **Multimedia** | `uploadMedia`, `downloadAny`, `downloadMedia` |
+| **Grupos** | `createGroup`, `getJoinedGroups`, `getGroupInfo`, `updateGroupParticipants`, `setGroupAnnounce` |
+| **Presencia** | `sendPresence`, `sendChatPresence`, `subscribePresence` |
+| **Privacidad** | `getPrivacySettings`, `setPrivacySetting`, `getBlocklist`, `updateBlocklist` |
+| **Encuestas** | `sendPollCreation`, `sendPollVote` |
+| **Canales** | `createNewsletter`, `getSubscribedNewsletters`, `followNewsletter` |
+
+Consulta la [Referencia de la API](/docs/api/overview) para la lista completa.
+
+## Ejemplo Completo
+
+```typescript
+import { createClient } from "@whatsmeow-node/whatsmeow-node";
+import qrcode from "qrcode-terminal";
+
+const client = createClient({ store: "session.db" });
+
+client.on("error", (err) => console.error("Error:", err));
+client.on("logged_out", ({ reason }) => {
+  console.error(`Logged out: ${reason}`);
+  client.close();
+  process.exit(1);
+});
+
+client.on("message", async ({ info, message }) => {
+  if (info.isFromMe) return;
+
+  const text =
+    (message.conversation as string) ??
+    (message.extendedTextMessage as { text?: string } | undefined)?.text;
+
+  if (text) {
+    console.log(`${info.pushName}: ${text}`);
+    await client.markRead([info.id], info.chat, info.sender);
+  }
+});
+
+async function main() {
+  const { jid } = await client.init();
+
+  if (jid) {
+    await client.connect();
+    console.log(`Connected as ${jid}`);
+  } else {
+    client.on("qr", ({ code }) => qrcode.generate(code, { small: true }));
+    await client.getQRChannel();
+    await client.connect();
+  }
+
+  await client.sendPresence("available");
+
+  process.on("SIGINT", async () => {
+    await client.sendPresence("unavailable");
+    await client.disconnect();
+    client.close();
+    process.exit(0);
+  });
+}
+
+main().catch(console.error);
+```
+
+## Errores Comunes
+
+:::warning No necesitas instalar Go
+No necesitas instalar Go. El binario precompilado viene incluido en el paquete npm. Si estás intentando compilar whatsmeow por tu cuenta, estás complicando las cosas — solo usa `npm install`.
+:::
+
+:::warning Formato de JID
+Los JID de WhatsApp se ven como `5512345678@s.whatsapp.net` (individual) o `120363XXXXX@g.us` (grupo). No incluyas el prefijo `+`.
+:::
+
+:::warning Gestión de sesión
+La base de datos de sesión contiene claves de cifrado. Si la eliminas, tendrás que vincular de nuevo. En producción, haz respaldo o usa PostgreSQL.
+:::
+
+<RelatedGuides slugs={["pair-whatsapp", "build-a-bot", "send-messages-typescript", "migrate-from-baileys"]} />

--- a/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/automate-group-messages.md
+++ b/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/automate-group-messages.md
@@ -1,0 +1,355 @@
+---
+title: "Como Automatizar Mensagens em Grupos do WhatsApp"
+sidebar_label: Automatizar Mensagens de Grupo
+sidebar_position: 12
+description: "Automatize mensagens em grupos do WhatsApp com Node.js — envie para grupos, mencione membros, crie grupos, gerencie participantes e faça broadcast para vários grupos."
+keywords: [automatizar mensagens grupo whatsapp, bot grupo whatsapp nodejs, enviar mensagem grupo whatsapp api, mensagem em massa grupo whatsapp, automação grupo whatsapp typescript]
+---
+
+import Head from '@docusaurus/Head';
+import {RelatedGuides} from '@site/src/components/RelatedGuides';
+
+<Head>
+  <meta property="og:image" content="https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/automate-group-messages.png" />
+  <meta name="twitter:image" content="https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/automate-group-messages.png" />
+  <script type="application/ld+json">
+    {JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "HowTo",
+      "name": "How to Automate Group Messages in WhatsApp",
+      "description": "Automate WhatsApp group messaging with Node.js — send to groups, mention members, create groups, manage participants, and broadcast to multiple groups.",
+      "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/automate-group-messages.png",
+      "step": [
+        {"@type": "HowToStep", "name": "List Your Groups", "text": "Use getJoinedGroups() to discover all groups you're a member of, with participant lists and settings."},
+        {"@type": "HowToStep", "name": "Send Messages to Groups", "text": "Use sendMessage() with a group JID (ending in @g.us) to send text messages to any group."},
+        {"@type": "HowToStep", "name": "Mention Group Members", "text": "Include mentionedJid in contextInfo with extendedTextMessage to @mention specific members or everyone."},
+        {"@type": "HowToStep", "name": "Listen for Group Events", "text": "Handle group:info events to react to joins, leaves, promotions, and setting changes."},
+        {"@type": "HowToStep", "name": "Broadcast to Multiple Groups", "text": "Iterate over groups with a delay between sends to avoid rate limiting."}
+      ]
+    })}
+  </script>
+  <script type="application/ld+json">
+    {JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "Article",
+      "headline": "How to Automate Group Messages in WhatsApp",
+      "description": "Automate WhatsApp group messaging with Node.js — send to groups, mention members, create groups, manage participants, and broadcast to multiple groups.",
+      "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/automate-group-messages.png",
+      "author": {"@type": "Organization", "name": "whatsmeow-node", "url": "https://nicastelo.github.io/whatsmeow-node/"},
+      "publisher": {"@type": "Organization", "name": "whatsmeow-node", "logo": {"@type": "ImageObject", "url": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/automate-group-messages.png"}}
+    })}
+  </script>
+</Head>
+
+![Como Automatizar Mensagens em Grupos do WhatsApp](/img/guides/pt-BR/automate-group-messages.png)
+![Como Automatizar Mensagens em Grupos do WhatsApp](/img/guides/pt-BR/automate-group-messages-light.png)
+
+# Como Automatizar Mensagens em Grupos do WhatsApp
+
+O whatsmeow-node dá controle total sobre grupos do WhatsApp — enviar mensagens, mencionar membros, criar grupos, gerenciar participantes e fazer broadcast para vários grupos. Este guia cobre as tarefas mais comuns de automação de grupo.
+
+## Pré-requisitos
+
+- Uma sessão pareada do whatsmeow-node ([Como Parear](pair-whatsapp))
+- Ser membro dos grupos que deseja enviar mensagens (não é possível enviar para grupos em que você não entrou)
+
+## Listar Seus Grupos
+
+Comece descobrindo em quais grupos você está:
+
+```typescript
+const groups = await client.getJoinedGroups();
+
+for (const g of groups) {
+  console.log(`${g.name} (${g.jid}) — ${g.participants.length} members`);
+}
+```
+
+Cada grupo tem um JID terminando em `@g.us` — é isso que você passa para `sendMessage()`.
+
+## Enviar uma Mensagem para um Grupo
+
+Enviar para um grupo funciona da mesma forma que enviar para um indivíduo — basta usar o JID do grupo:
+
+```typescript
+const groupJid = "120363XXXXX@g.us";
+await client.sendMessage(groupJid, { conversation: "Hello group!" });
+```
+
+## Mencionar Membros do Grupo
+
+### Mencionar membros específicos
+
+Inclua os JIDs em `mentionedJid` e use `@<número>` no corpo do texto:
+
+```typescript
+const memberJid = "5512345678@s.whatsapp.net";
+
+await client.sendRawMessage(groupJid, {
+  extendedTextMessage: {
+    text: `Hey @${memberJid.split("@")[0]}, check this out!`,
+    contextInfo: {
+      mentionedJid: [memberJid],
+    },
+  },
+});
+```
+
+### Mencionar todos
+
+Busque os participantes do grupo e monte a lista de menções:
+
+```typescript
+const group = await client.getGroupInfo(groupJid);
+const jids = group.participants.map((p) => p.jid);
+const mentions = jids.map((j) => `@${j.split("@")[0]}`).join(" ");
+
+await client.sendRawMessage(groupJid, {
+  extendedTextMessage: {
+    text: `Attention everyone: ${mentions}`,
+    contextInfo: { mentionedJid: jids },
+  },
+});
+```
+
+## Ouvir Eventos de Grupo
+
+Reaja a mudanças nos seus grupos:
+
+```typescript
+// Member changes and setting updates
+client.on("group:info", (event) => {
+  if (event.join) {
+    console.log(`New members in ${event.jid}: ${event.join.join(", ")}`);
+    // Welcome new members
+    for (const newMember of event.join) {
+      client.sendRawMessage(event.jid, {
+        extendedTextMessage: {
+          text: `Welcome @${newMember.split("@")[0]}!`,
+          contextInfo: { mentionedJid: [newMember] },
+        },
+      });
+    }
+  }
+
+  if (event.leave) {
+    console.log(`Left ${event.jid}: ${event.leave.join(", ")}`);
+  }
+
+  if (event.name) {
+    console.log(`Group renamed to: ${event.name}`);
+  }
+});
+
+// When you're added to a new group
+client.on("group:joined", ({ jid, name }) => {
+  console.log(`Joined group: ${name} (${jid})`);
+});
+```
+
+## Responder Mensagens de Grupo
+
+Trate mensagens de forma diferente dependendo se são de grupo:
+
+```typescript
+client.on("message", async ({ info, message }) => {
+  if (info.isFromMe) return;
+  if (!info.isGroup) return; // Only handle group messages
+
+  const text =
+    (message.conversation as string) ??
+    (message.extendedTextMessage as { text?: string } | undefined)?.text;
+  if (!text) return;
+
+  // In groups, info.chat is the group JID, info.sender is the person
+  console.log(`[${info.chat}] ${info.pushName}: ${text}`);
+
+  if (text === "!members") {
+    const group = await client.getGroupInfo(info.chat);
+    const list = group.participants
+      .map((p) => `- ${p.jid}${p.isAdmin ? " (admin)" : ""}`)
+      .join("\n");
+    await client.sendMessage(info.chat, {
+      conversation: `Members:\n${list}`,
+    });
+  }
+});
+```
+
+## Broadcast para Vários Grupos
+
+Envie a mesma mensagem para diversos grupos com um delay para evitar rate limiting:
+
+```typescript
+const groups = await client.getJoinedGroups();
+const targetGroups = groups.filter((g) => g.name.startsWith("Team "));
+
+for (const group of targetGroups) {
+  await client.sendMessage(group.jid, {
+    conversation: "Weekly reminder: standup at 9 AM tomorrow",
+  });
+
+  // Wait between sends to avoid rate limiting
+  await new Promise((r) => setTimeout(r, 2000));
+}
+
+console.log(`Sent to ${targetGroups.length} groups`);
+```
+
+:::warning Rate limiting
+O WhatsApp limita a taxa de envio, especialmente em massa. Espaçe as mensagens de 1 a 3 segundos. Enviar rápido demais pode restringir temporariamente sua conta. Veja [Rate Limiting](/docs/rate-limiting).
+:::
+
+## Criar e Configurar Grupos
+
+### Criar um grupo
+
+```typescript
+const newGroup = await client.createGroup("Project Alpha", [
+  "5512345678@s.whatsapp.net",
+  "5598765432@s.whatsapp.net",
+]);
+
+console.log(`Created group: ${newGroup.name} (${newGroup.jid})`);
+```
+
+### Configurar ajustes
+
+```typescript
+await client.setGroupDescription(groupJid, "Discussion for Project Alpha");
+await client.setGroupAnnounce(groupJid, true);  // Only admins can send
+await client.setGroupLocked(groupJid, true);     // Only admins can edit info
+```
+
+### Gerenciar participantes
+
+```typescript
+// Add members
+await client.updateGroupParticipants(groupJid, [newMemberJid], "add");
+
+// Promote to admin
+await client.updateGroupParticipants(groupJid, [memberJid], "promote");
+
+// Remove a member
+await client.updateGroupParticipants(groupJid, [memberJid], "remove");
+```
+
+### Compartilhar link de convite
+
+```typescript
+const link = await client.getGroupInviteLink(groupJid);
+console.log(`Invite link: ${link}`);
+
+// Reset the link (invalidates the old one)
+const newLink = await client.getGroupInviteLink(groupJid, true);
+```
+
+## Exemplo Completo
+
+Um bot de gerenciamento de grupo que trata comandos e dá boas-vindas a novos membros:
+
+```typescript
+import { createClient } from "@whatsmeow-node/whatsmeow-node";
+
+const client = createClient({ store: "session.db" });
+
+client.on("error", (err) => console.error("Error:", err));
+
+// Welcome new members
+client.on("group:info", async (event) => {
+  if (!event.join) return;
+
+  for (const jid of event.join) {
+    await client.sendRawMessage(event.jid, {
+      extendedTextMessage: {
+        text: `Welcome @${jid.split("@")[0]}! Type !help for available commands.`,
+        contextInfo: { mentionedJid: [jid] },
+      },
+    });
+  }
+});
+
+// Handle group commands
+client.on("message", async ({ info, message }) => {
+  if (info.isFromMe || !info.isGroup) return;
+
+  const text =
+    (message.conversation as string) ??
+    (message.extendedTextMessage as { text?: string } | undefined)?.text;
+  if (!text?.startsWith("!")) return;
+
+  await client.markRead([info.id], info.chat, info.sender);
+  const command = text.toLowerCase().trim();
+
+  if (command === "!help") {
+    await client.sendMessage(info.chat, {
+      conversation: "Commands:\n!help — show this message\n!members — list members\n!invite — get invite link",
+    });
+  }
+
+  if (command === "!members") {
+    const group = await client.getGroupInfo(info.chat);
+    const list = group.participants
+      .map((p) => {
+        const role = p.isSuperAdmin ? "owner" : p.isAdmin ? "admin" : "member";
+        return `- @${p.jid.split("@")[0]} (${role})`;
+      })
+      .join("\n");
+
+    await client.sendRawMessage(info.chat, {
+      extendedTextMessage: {
+        text: `Members (${group.participants.length}):\n${list}`,
+        contextInfo: {
+          mentionedJid: group.participants.map((p) => p.jid),
+        },
+      },
+    });
+  }
+
+  if (command === "!invite") {
+    const link = await client.getGroupInviteLink(info.chat);
+    await client.sendMessage(info.chat, { conversation: link });
+  }
+});
+
+async function main() {
+  const { jid } = await client.init();
+  if (!jid) {
+    console.error("Not paired! See: How to Pair WhatsApp");
+    process.exit(1);
+  }
+
+  await client.connect();
+  await client.sendPresence("available");
+  console.log("Group bot is online!");
+
+  process.on("SIGINT", async () => {
+    await client.sendPresence("unavailable");
+    await client.disconnect();
+    client.close();
+    process.exit(0);
+  });
+}
+
+main().catch(console.error);
+```
+
+## Erros Comuns
+
+:::warning Envie para `info.chat`, não para `info.sender`
+Em grupos, `info.chat` é o JID do grupo e `info.sender` é o indivíduo. Sempre responda para `info.chat` — enviar para `info.sender` inicia uma conversa privada.
+:::
+
+:::warning Grupos somente anúncios
+Se um grupo tem `announce: true`, apenas administradores podem enviar mensagens. Seu bot precisa ser admin para enviar mensagens nesses grupos.
+:::
+
+:::warning Rate limiting em broadcasts
+Enviar a mesma mensagem para muitos grupos rapidamente vai acionar o rate limiter do WhatsApp. Sempre adicione um delay (1-3 segundos) entre os envios. Veja [Rate Limiting](/docs/rate-limiting).
+:::
+
+:::warning Operações de admin em grupo
+`updateGroupParticipants` com `"promote"`, `"demote"` ou `"remove"` exige que seu bot seja admin do grupo. `"add"` também pode exigir permissão de admin dependendo das configurações do grupo.
+:::
+
+<RelatedGuides slugs={["build-a-bot", "send-messages-typescript", "send-notifications", "poll-bot"]} />

--- a/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/automate-group-messages.md
+++ b/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/automate-group-messages.md
@@ -16,15 +16,15 @@ import {RelatedGuides} from '@site/src/components/RelatedGuides';
     {JSON.stringify({
       "@context": "https://schema.org",
       "@type": "HowTo",
-      "name": "How to Automate Group Messages in WhatsApp",
-      "description": "Automate WhatsApp group messaging with Node.js — send to groups, mention members, create groups, manage participants, and broadcast to multiple groups.",
+      "name": "Como Automatizar Mensagens em Grupos do WhatsApp",
+      "description": "Automatize mensagens em grupos do WhatsApp com Node.js — envie para grupos, mencione membros, crie grupos, gerencie participantes e faça broadcast para vários grupos.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/automate-group-messages.png",
       "step": [
-        {"@type": "HowToStep", "name": "List Your Groups", "text": "Use getJoinedGroups() to discover all groups you're a member of, with participant lists and settings."},
-        {"@type": "HowToStep", "name": "Send Messages to Groups", "text": "Use sendMessage() with a group JID (ending in @g.us) to send text messages to any group."},
-        {"@type": "HowToStep", "name": "Mention Group Members", "text": "Include mentionedJid in contextInfo with extendedTextMessage to @mention specific members or everyone."},
-        {"@type": "HowToStep", "name": "Listen for Group Events", "text": "Handle group:info events to react to joins, leaves, promotions, and setting changes."},
-        {"@type": "HowToStep", "name": "Broadcast to Multiple Groups", "text": "Iterate over groups with a delay between sends to avoid rate limiting."}
+        {"@type": "HowToStep", "name": "Listar Seus Grupos", "text": "Use getJoinedGroups() para descobrir todos os grupos dos quais você é membro, com listas de participantes e configurações."},
+        {"@type": "HowToStep", "name": "Enviar Mensagens para Grupos", "text": "Use sendMessage() com um JID de grupo (terminando em @g.us) para enviar mensagens de texto para qualquer grupo."},
+        {"@type": "HowToStep", "name": "Mencionar Membros do Grupo", "text": "Inclua mentionedJid em contextInfo com extendedTextMessage para @mencionar membros específicos ou todos."},
+        {"@type": "HowToStep", "name": "Ouvir Eventos de Grupo", "text": "Trate eventos group:info para reagir a entradas, saídas, promoções e mudanças de configuração."},
+        {"@type": "HowToStep", "name": "Broadcast para Vários Grupos", "text": "Itere sobre os grupos com um delay entre os envios para evitar rate limiting."}
       ]
     })}
   </script>
@@ -32,8 +32,8 @@ import {RelatedGuides} from '@site/src/components/RelatedGuides';
     {JSON.stringify({
       "@context": "https://schema.org",
       "@type": "Article",
-      "headline": "How to Automate Group Messages in WhatsApp",
-      "description": "Automate WhatsApp group messaging with Node.js — send to groups, mention members, create groups, manage participants, and broadcast to multiple groups.",
+      "headline": "Como Automatizar Mensagens em Grupos do WhatsApp",
+      "description": "Automatize mensagens em grupos do WhatsApp com Node.js — envie para grupos, mencione membros, crie grupos, gerencie participantes e faça broadcast para vários grupos.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/automate-group-messages.png",
       "author": {"@type": "Organization", "name": "whatsmeow-node", "url": "https://nicastelo.github.io/whatsmeow-node/"},
       "publisher": {"@type": "Organization", "name": "whatsmeow-node", "logo": {"@type": "ImageObject", "url": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/automate-group-messages.png"}}

--- a/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/build-a-bot.md
+++ b/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/build-a-bot.md
@@ -19,12 +19,12 @@ import Head from '@docusaurus/Head';
       "description": "Crie um bot de WhatsApp com Node.js e TypeScript — receba mensagens, trate comandos, responda com citações e gerencie conexões.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/build-a-bot.png",
       "step": [
-        {"@type": "HowToStep", "name": "Create the Client", "text": "Initialize a WhatsmeowClient with createClient() and a session store."},
-        {"@type": "HowToStep", "name": "Handle Incoming Messages", "text": "Listen for the message event and extract text from conversation or extendedTextMessage."},
-        {"@type": "HowToStep", "name": "Reply to Messages", "text": "Use sendMessage for text or sendRawMessage with contextInfo for quoted replies."},
-        {"@type": "HowToStep", "name": "Add Commands", "text": "Route messages starting with ! to command handlers like !ping and !help."},
-        {"@type": "HowToStep", "name": "Handle Errors and Reconnection", "text": "Listen for logged_out and disconnected events. Auto-reconnect is built-in."},
-        {"@type": "HowToStep", "name": "Graceful Shutdown", "text": "Handle SIGINT to set presence unavailable and disconnect cleanly."}
+        {"@type": "HowToStep", "name": "Criar o Client", "text": "Inicialize um WhatsmeowClient com createClient() e um store de sessão."},
+        {"@type": "HowToStep", "name": "Tratar Mensagens Recebidas", "text": "Escute o evento message e extraia o texto de conversation ou extendedTextMessage."},
+        {"@type": "HowToStep", "name": "Responder Mensagens", "text": "Use sendMessage para texto ou sendRawMessage com contextInfo para respostas com citação."},
+        {"@type": "HowToStep", "name": "Adicionar Comandos", "text": "Roteie mensagens que começam com ! para handlers de comandos como !ping e !help."},
+        {"@type": "HowToStep", "name": "Tratar Erros e Reconexão", "text": "Escute os eventos logged_out e disconnected. A reconexão automática é embutida."},
+        {"@type": "HowToStep", "name": "Encerramento Gracioso", "text": "Trate o SIGINT para definir a presença como indisponível e desconectar de forma limpa."}
       ]
     })}
   </script>

--- a/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/connect-to-ai.md
+++ b/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/connect-to-ai.md
@@ -19,10 +19,10 @@ import Head from '@docusaurus/Head';
       "description": "Crie um chatbot de WhatsApp com IA conectando whatsmeow-node ao Claude via Anthropic SDK. Inclui histórico de conversa e indicadores de digitação.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/connect-to-ai.png",
       "step": [
-        {"@type": "HowToStep", "name": "Set Up Both Clients", "text": "Initialize WhatsmeowClient with createClient() and Anthropic client with new Anthropic()."},
-        {"@type": "HowToStep", "name": "Handle Incoming Messages", "text": "Listen for the message event, skip own messages, show typing, and extract text."},
-        {"@type": "HowToStep", "name": "Send to Claude", "text": "Call anthropic.messages.create() with the user message and send the response back via sendMessage."},
-        {"@type": "HowToStep", "name": "Add Conversation History", "text": "Store message history per user JID in a Map and pass it to Claude for multi-turn conversations."}
+        {"@type": "HowToStep", "name": "Configurar os Dois Clients", "text": "Inicialize o WhatsmeowClient com createClient() e o client da Anthropic com new Anthropic()."},
+        {"@type": "HowToStep", "name": "Tratar Mensagens Recebidas", "text": "Escute o evento message, ignore mensagens próprias, mostre digitação e extraia o texto."},
+        {"@type": "HowToStep", "name": "Enviar para o Claude", "text": "Chame anthropic.messages.create() com a mensagem do usuário e envie a resposta de volta via sendMessage."},
+        {"@type": "HowToStep", "name": "Adicionar Histórico de Conversas", "text": "Armazene o histórico de mensagens por JID do usuário em um Map e passe para o Claude para conversas com múltiplas trocas."}
       ]
     })}
   </script>

--- a/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/connect-to-chatgpt.md
+++ b/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/connect-to-chatgpt.md
@@ -16,14 +16,14 @@ import {RelatedGuides} from '@site/src/components/RelatedGuides';
     {JSON.stringify({
       "@context": "https://schema.org",
       "@type": "HowTo",
-      "name": "How to Connect WhatsApp to ChatGPT (OpenAI)",
-      "description": "Build a WhatsApp chatbot powered by ChatGPT using whatsmeow-node and the OpenAI SDK. Includes conversation history, typing indicators, and GPT-4.1.",
+      "name": "Como Conectar o WhatsApp ao ChatGPT (OpenAI)",
+      "description": "Crie um chatbot de WhatsApp com ChatGPT usando whatsmeow-node e o SDK da OpenAI. Inclui histórico de conversas, indicadores de digitação e GPT-4.1.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/connect-to-chatgpt.png",
       "step": [
-        {"@type": "HowToStep", "name": "Set Up Both Clients", "text": "Initialize WhatsmeowClient with createClient() and OpenAI client with new OpenAI()."},
-        {"@type": "HowToStep", "name": "Handle Incoming Messages", "text": "Listen for the message event, skip own messages, show typing, and extract text."},
-        {"@type": "HowToStep", "name": "Send to ChatGPT", "text": "Call openai.chat.completions.create() with the user message and send the response back via sendMessage."},
-        {"@type": "HowToStep", "name": "Add Conversation History", "text": "Store message history per user JID in a Map and pass it to ChatGPT for multi-turn conversations."}
+        {"@type": "HowToStep", "name": "Configurar os Dois Clients", "text": "Inicialize o WhatsmeowClient com createClient() e o client da OpenAI com new OpenAI()."},
+        {"@type": "HowToStep", "name": "Tratar Mensagens Recebidas", "text": "Escute o evento message, ignore mensagens próprias, mostre digitação e extraia o texto."},
+        {"@type": "HowToStep", "name": "Enviar para o ChatGPT", "text": "Chame openai.chat.completions.create() com a mensagem do usuário e envie a resposta de volta via sendMessage."},
+        {"@type": "HowToStep", "name": "Adicionar Histórico de Conversas", "text": "Armazene o histórico de mensagens por JID do usuário em um Map e passe para o ChatGPT para conversas com múltiplas trocas."}
       ]
     })}
   </script>
@@ -31,8 +31,8 @@ import {RelatedGuides} from '@site/src/components/RelatedGuides';
     {JSON.stringify({
       "@context": "https://schema.org",
       "@type": "Article",
-      "headline": "How to Connect WhatsApp to ChatGPT (OpenAI)",
-      "description": "Build a WhatsApp chatbot powered by ChatGPT using whatsmeow-node and the OpenAI SDK. Includes conversation history, typing indicators, and GPT-4.1.",
+      "headline": "Como Conectar o WhatsApp ao ChatGPT (OpenAI)",
+      "description": "Crie um chatbot de WhatsApp com ChatGPT usando whatsmeow-node e o SDK da OpenAI. Inclui histórico de conversas, indicadores de digitação e GPT-4.1.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/connect-to-chatgpt.png",
       "author": {"@type": "Organization", "name": "whatsmeow-node", "url": "https://nicastelo.github.io/whatsmeow-node/"},
       "publisher": {"@type": "Organization", "name": "whatsmeow-node", "logo": {"@type": "ImageObject", "url": "https://nicastelo.github.io/whatsmeow-node/img/image.png"}}

--- a/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/connect-to-chatgpt.md
+++ b/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/connect-to-chatgpt.md
@@ -1,0 +1,235 @@
+---
+title: "Como Conectar o WhatsApp ao ChatGPT (OpenAI)"
+sidebar_label: Conectar ao ChatGPT
+sidebar_position: 13
+description: "Crie um chatbot de WhatsApp com ChatGPT usando whatsmeow-node e o SDK da OpenAI. Inclui histórico de conversas, indicadores de digitação e GPT-4.1."
+keywords: [conectar whatsapp chatgpt, bot whatsapp chatgpt, bot whatsapp openai nodejs, bot whatsapp gpt typescript, integração chatgpt whatsapp]
+---
+
+import Head from '@docusaurus/Head';
+import {RelatedGuides} from '@site/src/components/RelatedGuides';
+
+<Head>
+  <meta property="og:image" content="https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/connect-to-chatgpt.png" />
+  <meta name="twitter:image" content="https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/connect-to-chatgpt.png" />
+  <script type="application/ld+json">
+    {JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "HowTo",
+      "name": "How to Connect WhatsApp to ChatGPT (OpenAI)",
+      "description": "Build a WhatsApp chatbot powered by ChatGPT using whatsmeow-node and the OpenAI SDK. Includes conversation history, typing indicators, and GPT-4.1.",
+      "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/connect-to-chatgpt.png",
+      "step": [
+        {"@type": "HowToStep", "name": "Set Up Both Clients", "text": "Initialize WhatsmeowClient with createClient() and OpenAI client with new OpenAI()."},
+        {"@type": "HowToStep", "name": "Handle Incoming Messages", "text": "Listen for the message event, skip own messages, show typing, and extract text."},
+        {"@type": "HowToStep", "name": "Send to ChatGPT", "text": "Call openai.chat.completions.create() with the user message and send the response back via sendMessage."},
+        {"@type": "HowToStep", "name": "Add Conversation History", "text": "Store message history per user JID in a Map and pass it to ChatGPT for multi-turn conversations."}
+      ]
+    })}
+  </script>
+  <script type="application/ld+json">
+    {JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "Article",
+      "headline": "How to Connect WhatsApp to ChatGPT (OpenAI)",
+      "description": "Build a WhatsApp chatbot powered by ChatGPT using whatsmeow-node and the OpenAI SDK. Includes conversation history, typing indicators, and GPT-4.1.",
+      "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/connect-to-chatgpt.png",
+      "author": {"@type": "Organization", "name": "whatsmeow-node", "url": "https://nicastelo.github.io/whatsmeow-node/"},
+      "publisher": {"@type": "Organization", "name": "whatsmeow-node", "logo": {"@type": "ImageObject", "url": "https://nicastelo.github.io/whatsmeow-node/img/image.png"}}
+    })}
+  </script>
+</Head>
+
+![Como Conectar o WhatsApp ao ChatGPT (OpenAI)](/img/guides/pt-BR/connect-to-chatgpt.png)
+![Como Conectar o WhatsApp ao ChatGPT (OpenAI)](/img/guides/pt-BR/connect-to-chatgpt-light.png)
+
+# Como Conectar o WhatsApp ao ChatGPT (OpenAI)
+
+Combine o whatsmeow-node com o SDK da OpenAI para criar um chatbot de WhatsApp com GPT-4.1. As mensagens chegam pelo WhatsApp, são enviadas para a OpenAI para gerar uma resposta, e a resposta volta para o usuário — com indicadores de digitação enquanto o modelo pensa.
+
+## Pré-requisitos
+
+- Uma sessão pareada do whatsmeow-node ([Como Parear](pair-whatsapp))
+- Uma chave de API da OpenAI (defina como variável de ambiente `OPENAI_API_KEY`)
+- O SDK da OpenAI: `npm install openai`
+
+## Passo 1: Configurar os Dois Clients
+
+```typescript
+import { createClient } from "@whatsmeow-node/whatsmeow-node";
+import OpenAI from "openai";
+
+const client = createClient({ store: "session.db" });
+const openai = new OpenAI(); // reads OPENAI_API_KEY from env
+
+const SYSTEM_PROMPT = "You are a helpful WhatsApp assistant. Keep responses concise — under 500 characters when possible, since this is a chat interface.";
+```
+
+## Passo 2: Tratar Mensagens Recebidas
+
+```typescript
+client.on("message", async ({ info, message }) => {
+  if (info.isFromMe) return;
+
+  const text =
+    (message.conversation as string) ??
+    (message.extendedTextMessage as { text?: string } | undefined)?.text;
+  if (!text) return;
+
+  await client.sendChatPresence(info.chat, "composing");
+
+  const reply = await askChatGPT(info.sender, text);
+  await client.sendMessage(info.chat, { conversation: reply });
+});
+```
+
+## Passo 3: Enviar para o ChatGPT
+
+```typescript
+async function askChatGPT(userJid: string, userMessage: string): Promise<string> {
+  const response = await openai.chat.completions.create({
+    model: "gpt-4.1",
+    messages: [
+      { role: "system", content: SYSTEM_PROMPT },
+      { role: "user", content: userMessage },
+    ],
+  });
+
+  return response.choices[0].message.content ?? "I couldn't generate a response.";
+}
+```
+
+## Passo 4: Adicionar Histórico de Conversas
+
+Para conversas com múltiplas trocas, armazene o histórico de mensagens por usuário:
+
+```typescript
+import type { ChatCompletionMessageParam } from "openai/resources/chat/completions";
+
+const conversations = new Map<string, ChatCompletionMessageParam[]>();
+const MAX_HISTORY = 20;
+
+async function askChatGPT(userJid: string, userMessage: string): Promise<string> {
+  const history = conversations.get(userJid) ?? [];
+  history.push({ role: "user", content: userMessage });
+
+  if (history.length > MAX_HISTORY) {
+    history.splice(0, history.length - MAX_HISTORY);
+  }
+
+  const response = await openai.chat.completions.create({
+    model: "gpt-4.1",
+    messages: [{ role: "system", content: SYSTEM_PROMPT }, ...history],
+  });
+
+  const reply = response.choices[0].message.content ?? "I couldn't generate a response.";
+
+  history.push({ role: "assistant", content: reply });
+  conversations.set(userJid, history);
+
+  return reply;
+}
+```
+
+## Exemplo Completo
+
+```typescript
+import { createClient } from "@whatsmeow-node/whatsmeow-node";
+import OpenAI from "openai";
+import type { ChatCompletionMessageParam } from "openai/resources/chat/completions";
+
+const client = createClient({ store: "session.db" });
+const openai = new OpenAI();
+
+const SYSTEM_PROMPT =
+  "You are a helpful WhatsApp assistant. Keep responses concise — under 500 characters when possible, since this is a chat interface.";
+
+const conversations = new Map<string, ChatCompletionMessageParam[]>();
+const MAX_HISTORY = 20;
+
+async function askChatGPT(userJid: string, userMessage: string): Promise<string> {
+  const history = conversations.get(userJid) ?? [];
+  history.push({ role: "user", content: userMessage });
+
+  if (history.length > MAX_HISTORY) {
+    history.splice(0, history.length - MAX_HISTORY);
+  }
+
+  const response = await openai.chat.completions.create({
+    model: "gpt-4.1",
+    messages: [{ role: "system", content: SYSTEM_PROMPT }, ...history],
+  });
+
+  const reply = response.choices[0].message.content ?? "I couldn't generate a response.";
+
+  history.push({ role: "assistant", content: reply });
+  conversations.set(userJid, history);
+
+  return reply;
+}
+
+client.on("message", async ({ info, message }) => {
+  if (info.isFromMe) return;
+
+  const text =
+    (message.conversation as string) ??
+    (message.extendedTextMessage as { text?: string } | undefined)?.text;
+  if (!text) return;
+
+  console.log(`${info.pushName}: ${text}`);
+  await client.sendChatPresence(info.chat, "composing");
+
+  try {
+    const reply = await askChatGPT(info.sender, text);
+    await client.sendMessage(info.chat, { conversation: reply });
+    console.log(`→ ${reply.slice(0, 80)}...`);
+  } catch (err) {
+    console.error("OpenAI API error:", err);
+    await client.sendMessage(info.chat, {
+      conversation: "Sorry, I'm having trouble right now. Try again in a moment.",
+    });
+  }
+});
+
+client.on("logged_out", ({ reason }) => {
+  console.error(`Logged out: ${reason}`);
+  client.close();
+  process.exit(1);
+});
+
+async function main() {
+  const { jid } = await client.init();
+  if (!jid) {
+    console.error("Not paired! See: How to Pair WhatsApp");
+    process.exit(1);
+  }
+  await client.connect();
+  await client.sendPresence("available");
+  console.log("ChatGPT bot is online!");
+
+  process.on("SIGINT", async () => {
+    await client.sendPresence("unavailable");
+    await client.disconnect();
+    client.close();
+    process.exit(0);
+  });
+}
+
+main().catch(console.error);
+```
+
+## Erros Comuns
+
+:::warning Loops de eco
+Sempre verifique `info.isFromMe` primeiro. Sem isso, o bot envia uma mensagem, vê a própria mensagem, manda para o ChatGPT e responde de novo — para sempre.
+:::
+
+:::warning Exposição da chave de API
+Nunca coloque sua chave de API diretamente no código. Use variáveis de ambiente (`OPENAI_API_KEY`) ou um arquivo `.env` (adicionado ao `.gitignore`).
+:::
+
+:::warning Rate limits dos dois lados
+Tanto a API da OpenAI quanto o WhatsApp têm rate limits. Para a API da OpenAI, trate erros `429` com backoff exponencial. Para o WhatsApp, evite enviar muitas mensagens muito rápido — veja [Rate Limiting](/docs/rate-limiting).
+:::
+
+<RelatedGuides slugs={["connect-to-ai", "connect-to-gemini", "connect-to-ollama", "connect-to-deepseek"]} />

--- a/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/connect-to-deepseek.md
+++ b/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/connect-to-deepseek.md
@@ -1,0 +1,258 @@
+---
+title: "Como Conectar o WhatsApp ao DeepSeek"
+sidebar_label: Conectar ao DeepSeek
+sidebar_position: 15
+description: "Crie um chatbot de WhatsApp com DeepSeek usando whatsmeow-node e o SDK da OpenAI. O DeepSeek usa uma API compatível com a OpenAI."
+keywords: [conectar whatsapp deepseek, bot whatsapp deepseek, deepseek whatsapp nodejs, integração whatsapp deepseek, chatbot deepseek whatsapp]
+---
+
+import Head from '@docusaurus/Head';
+import {RelatedGuides} from '@site/src/components/RelatedGuides';
+
+<Head>
+  <meta property="og:image" content="https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/connect-to-deepseek.png" />
+  <meta name="twitter:image" content="https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/connect-to-deepseek.png" />
+  <script type="application/ld+json">
+    {JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "HowTo",
+      "name": "How to Connect WhatsApp to DeepSeek",
+      "description": "Build a WhatsApp chatbot powered by DeepSeek using whatsmeow-node and the OpenAI SDK. DeepSeek uses an OpenAI-compatible API.",
+      "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/connect-to-deepseek.png",
+      "step": [
+        {"@type": "HowToStep", "name": "Set Up Both Clients", "text": "Initialize WhatsmeowClient with createClient() and OpenAI client pointing to DeepSeek's base URL."},
+        {"@type": "HowToStep", "name": "Handle Incoming Messages", "text": "Listen for the message event, skip own messages, show typing, and extract text."},
+        {"@type": "HowToStep", "name": "Send to DeepSeek", "text": "Call openai.chat.completions.create() with the deepseek-chat model and send the response back via sendMessage."},
+        {"@type": "HowToStep", "name": "Add Conversation History", "text": "Store message history per user JID in a Map and pass it to DeepSeek for multi-turn conversations."}
+      ]
+    })}
+  </script>
+  <script type="application/ld+json">
+    {JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "Article",
+      "headline": "How to Connect WhatsApp to DeepSeek",
+      "description": "Build a WhatsApp chatbot powered by DeepSeek using whatsmeow-node and the OpenAI SDK. DeepSeek uses an OpenAI-compatible API.",
+      "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/connect-to-deepseek.png",
+      "author": {"@type": "Organization", "name": "whatsmeow-node", "url": "https://nicastelo.github.io/whatsmeow-node/"},
+      "publisher": {"@type": "Organization", "name": "whatsmeow-node", "logo": {"@type": "ImageObject", "url": "https://nicastelo.github.io/whatsmeow-node/img/image.png"}}
+    })}
+  </script>
+</Head>
+
+![Como Conectar o WhatsApp ao DeepSeek](/img/guides/pt-BR/connect-to-deepseek.png)
+![Como Conectar o WhatsApp ao DeepSeek](/img/guides/pt-BR/connect-to-deepseek-light.png)
+
+# Como Conectar o WhatsApp ao DeepSeek
+
+O DeepSeek expõe uma API compatível com a OpenAI, então você pode usar o mesmo pacote npm `openai` — basta apontar para o endpoint do DeepSeek. Isso facilita trocar entre OpenAI, DeepSeek e outros provedores compatíveis.
+
+## Pré-requisitos
+
+- Uma sessão pareada do whatsmeow-node ([Como Parear](pair-whatsapp))
+- Uma chave de API do DeepSeek (defina como variável de ambiente `DEEPSEEK_API_KEY`) — obtenha uma em [platform.deepseek.com](https://platform.deepseek.com/)
+- O SDK da OpenAI: `npm install openai`
+
+## Passo 1: Configurar os Dois Clients
+
+A única diferença em relação à OpenAI é o `baseURL` e a chave de API:
+
+```typescript
+import { createClient } from "@whatsmeow-node/whatsmeow-node";
+import OpenAI from "openai";
+
+const client = createClient({ store: "session.db" });
+const openai = new OpenAI({
+  baseURL: "https://api.deepseek.com",
+  apiKey: process.env.DEEPSEEK_API_KEY,
+});
+
+const SYSTEM_PROMPT = "You are a helpful WhatsApp assistant. Keep responses concise — under 500 characters when possible, since this is a chat interface.";
+```
+
+## Passo 2: Tratar Mensagens Recebidas
+
+```typescript
+client.on("message", async ({ info, message }) => {
+  if (info.isFromMe) return;
+
+  const text =
+    (message.conversation as string) ??
+    (message.extendedTextMessage as { text?: string } | undefined)?.text;
+  if (!text) return;
+
+  await client.sendChatPresence(info.chat, "composing");
+
+  const reply = await askDeepSeek(info.sender, text);
+  await client.sendMessage(info.chat, { conversation: reply });
+});
+```
+
+## Passo 3: Enviar para o DeepSeek
+
+```typescript
+async function askDeepSeek(userJid: string, userMessage: string): Promise<string> {
+  const response = await openai.chat.completions.create({
+    model: "deepseek-chat",
+    messages: [
+      { role: "system", content: SYSTEM_PROMPT },
+      { role: "user", content: userMessage },
+    ],
+  });
+
+  return response.choices[0].message.content ?? "I couldn't generate a response.";
+}
+```
+
+:::info
+O DeepSeek também oferece o `deepseek-reasoner` para tarefas de raciocínio complexo. Troque o nome do modelo para experimentar.
+:::
+
+## Passo 4: Adicionar Histórico de Conversas
+
+Como o DeepSeek usa o formato compatível com a OpenAI, o padrão de histórico é idêntico:
+
+```typescript
+import type { ChatCompletionMessageParam } from "openai/resources/chat/completions";
+
+const conversations = new Map<string, ChatCompletionMessageParam[]>();
+const MAX_HISTORY = 20;
+
+async function askDeepSeek(userJid: string, userMessage: string): Promise<string> {
+  const history = conversations.get(userJid) ?? [];
+  history.push({ role: "user", content: userMessage });
+
+  if (history.length > MAX_HISTORY) {
+    history.splice(0, history.length - MAX_HISTORY);
+  }
+
+  const response = await openai.chat.completions.create({
+    model: "deepseek-chat",
+    messages: [{ role: "system", content: SYSTEM_PROMPT }, ...history],
+  });
+
+  const reply = response.choices[0].message.content ?? "I couldn't generate a response.";
+
+  history.push({ role: "assistant", content: reply });
+  conversations.set(userJid, history);
+
+  return reply;
+}
+```
+
+## Exemplo Completo
+
+```typescript
+import { createClient } from "@whatsmeow-node/whatsmeow-node";
+import OpenAI from "openai";
+import type { ChatCompletionMessageParam } from "openai/resources/chat/completions";
+
+const client = createClient({ store: "session.db" });
+const openai = new OpenAI({
+  baseURL: "https://api.deepseek.com",
+  apiKey: process.env.DEEPSEEK_API_KEY,
+});
+
+const SYSTEM_PROMPT =
+  "You are a helpful WhatsApp assistant. Keep responses concise — under 500 characters when possible, since this is a chat interface.";
+
+const conversations = new Map<string, ChatCompletionMessageParam[]>();
+const MAX_HISTORY = 20;
+
+async function askDeepSeek(userJid: string, userMessage: string): Promise<string> {
+  const history = conversations.get(userJid) ?? [];
+  history.push({ role: "user", content: userMessage });
+
+  if (history.length > MAX_HISTORY) {
+    history.splice(0, history.length - MAX_HISTORY);
+  }
+
+  const response = await openai.chat.completions.create({
+    model: "deepseek-chat",
+    messages: [{ role: "system", content: SYSTEM_PROMPT }, ...history],
+  });
+
+  const reply = response.choices[0].message.content ?? "I couldn't generate a response.";
+
+  history.push({ role: "assistant", content: reply });
+  conversations.set(userJid, history);
+
+  return reply;
+}
+
+client.on("message", async ({ info, message }) => {
+  if (info.isFromMe) return;
+
+  const text =
+    (message.conversation as string) ??
+    (message.extendedTextMessage as { text?: string } | undefined)?.text;
+  if (!text) return;
+
+  console.log(`${info.pushName}: ${text}`);
+  await client.sendChatPresence(info.chat, "composing");
+
+  try {
+    const reply = await askDeepSeek(info.sender, text);
+    await client.sendMessage(info.chat, { conversation: reply });
+    console.log(`→ ${reply.slice(0, 80)}...`);
+  } catch (err) {
+    console.error("DeepSeek API error:", err);
+    await client.sendMessage(info.chat, {
+      conversation: "Sorry, I'm having trouble right now. Try again in a moment.",
+    });
+  }
+});
+
+client.on("logged_out", ({ reason }) => {
+  console.error(`Logged out: ${reason}`);
+  client.close();
+  process.exit(1);
+});
+
+async function main() {
+  const { jid } = await client.init();
+  if (!jid) {
+    console.error("Not paired! See: How to Pair WhatsApp");
+    process.exit(1);
+  }
+  await client.connect();
+  await client.sendPresence("available");
+  console.log("DeepSeek bot is online!");
+
+  process.on("SIGINT", async () => {
+    await client.sendPresence("unavailable");
+    await client.disconnect();
+    client.close();
+    process.exit(0);
+  });
+}
+
+main().catch(console.error);
+```
+
+## Alternando Entre Provedores
+
+Como DeepSeek, OpenAI e vários outros provedores usam o mesmo formato de API, você pode tornar o provedor configurável:
+
+```typescript
+const openai = new OpenAI({
+  baseURL: process.env.AI_BASE_URL ?? "https://api.openai.com/v1",
+  apiKey: process.env.AI_API_KEY,
+});
+
+const model = process.env.AI_MODEL ?? "gpt-4o";
+```
+
+Isso funciona com qualquer provedor compatível com a OpenAI — DeepSeek, Groq, Together AI, Mistral e mais.
+
+## Erros Comuns
+
+:::warning Loops de eco
+Sempre verifique `info.isFromMe` primeiro. Sem isso, o bot responde às próprias mensagens para sempre.
+:::
+
+:::warning Exposição da chave de API
+Nunca coloque sua chave de API diretamente no código. Use variáveis de ambiente ou um arquivo `.env` (adicionado ao `.gitignore`).
+:::
+
+<RelatedGuides slugs={["connect-to-chatgpt", "connect-to-ai", "connect-to-ollama"]} />

--- a/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/connect-to-deepseek.md
+++ b/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/connect-to-deepseek.md
@@ -16,14 +16,14 @@ import {RelatedGuides} from '@site/src/components/RelatedGuides';
     {JSON.stringify({
       "@context": "https://schema.org",
       "@type": "HowTo",
-      "name": "How to Connect WhatsApp to DeepSeek",
-      "description": "Build a WhatsApp chatbot powered by DeepSeek using whatsmeow-node and the OpenAI SDK. DeepSeek uses an OpenAI-compatible API.",
+      "name": "Como Conectar o WhatsApp ao DeepSeek",
+      "description": "Crie um chatbot de WhatsApp com DeepSeek usando whatsmeow-node e o SDK da OpenAI. O DeepSeek usa uma API compatível com a OpenAI.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/connect-to-deepseek.png",
       "step": [
-        {"@type": "HowToStep", "name": "Set Up Both Clients", "text": "Initialize WhatsmeowClient with createClient() and OpenAI client pointing to DeepSeek's base URL."},
-        {"@type": "HowToStep", "name": "Handle Incoming Messages", "text": "Listen for the message event, skip own messages, show typing, and extract text."},
-        {"@type": "HowToStep", "name": "Send to DeepSeek", "text": "Call openai.chat.completions.create() with the deepseek-chat model and send the response back via sendMessage."},
-        {"@type": "HowToStep", "name": "Add Conversation History", "text": "Store message history per user JID in a Map and pass it to DeepSeek for multi-turn conversations."}
+        {"@type": "HowToStep", "name": "Configurar os Dois Clients", "text": "Inicialize o WhatsmeowClient com createClient() e o client da OpenAI apontando para a URL base do DeepSeek."},
+        {"@type": "HowToStep", "name": "Tratar Mensagens Recebidas", "text": "Escute o evento message, ignore mensagens próprias, mostre digitação e extraia o texto."},
+        {"@type": "HowToStep", "name": "Enviar para o DeepSeek", "text": "Chame openai.chat.completions.create() com o modelo deepseek-chat e envie a resposta de volta via sendMessage."},
+        {"@type": "HowToStep", "name": "Adicionar Histórico de Conversas", "text": "Armazene o histórico de mensagens por JID do usuário em um Map e passe para o DeepSeek para conversas com múltiplas trocas."}
       ]
     })}
   </script>
@@ -31,8 +31,8 @@ import {RelatedGuides} from '@site/src/components/RelatedGuides';
     {JSON.stringify({
       "@context": "https://schema.org",
       "@type": "Article",
-      "headline": "How to Connect WhatsApp to DeepSeek",
-      "description": "Build a WhatsApp chatbot powered by DeepSeek using whatsmeow-node and the OpenAI SDK. DeepSeek uses an OpenAI-compatible API.",
+      "headline": "Como Conectar o WhatsApp ao DeepSeek",
+      "description": "Crie um chatbot de WhatsApp com DeepSeek usando whatsmeow-node e o SDK da OpenAI. O DeepSeek usa uma API compatível com a OpenAI.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/connect-to-deepseek.png",
       "author": {"@type": "Organization", "name": "whatsmeow-node", "url": "https://nicastelo.github.io/whatsmeow-node/"},
       "publisher": {"@type": "Organization", "name": "whatsmeow-node", "logo": {"@type": "ImageObject", "url": "https://nicastelo.github.io/whatsmeow-node/img/image.png"}}

--- a/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/connect-to-gemini.md
+++ b/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/connect-to-gemini.md
@@ -16,14 +16,14 @@ import {RelatedGuides} from '@site/src/components/RelatedGuides';
     {JSON.stringify({
       "@context": "https://schema.org",
       "@type": "HowTo",
-      "name": "How to Connect WhatsApp to Google Gemini",
-      "description": "Build a WhatsApp chatbot powered by Google Gemini using whatsmeow-node and the Google GenAI SDK. Includes conversation history and typing indicators.",
+      "name": "Como Conectar o WhatsApp ao Google Gemini",
+      "description": "Crie um chatbot de WhatsApp com Google Gemini usando whatsmeow-node e o SDK Google GenAI. Inclui histórico de conversas e indicadores de digitação.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/connect-to-gemini.png",
       "step": [
-        {"@type": "HowToStep", "name": "Set Up Both Clients", "text": "Initialize WhatsmeowClient with createClient() and Google GenAI with new GoogleGenAI()."},
-        {"@type": "HowToStep", "name": "Handle Incoming Messages", "text": "Listen for the message event, skip own messages, show typing, and extract text."},
-        {"@type": "HowToStep", "name": "Send to Gemini", "text": "Call ai.models.generateContent() with the user message and send the response back via sendMessage."},
-        {"@type": "HowToStep", "name": "Add Conversation History", "text": "Use Gemini's multi-turn chat feature to maintain conversation context per user."}
+        {"@type": "HowToStep", "name": "Configurar os Dois Clients", "text": "Inicialize o WhatsmeowClient com createClient() e o Google GenAI com new GoogleGenAI()."},
+        {"@type": "HowToStep", "name": "Tratar Mensagens Recebidas", "text": "Escute o evento message, ignore mensagens próprias, mostre digitação e extraia o texto."},
+        {"@type": "HowToStep", "name": "Enviar para o Gemini", "text": "Chame ai.models.generateContent() com a mensagem do usuário e envie a resposta de volta via sendMessage."},
+        {"@type": "HowToStep", "name": "Adicionar Histórico de Conversas", "text": "Use o recurso de chat multi-turno do Gemini para manter o contexto da conversa por usuário."}
       ]
     })}
   </script>
@@ -31,8 +31,8 @@ import {RelatedGuides} from '@site/src/components/RelatedGuides';
     {JSON.stringify({
       "@context": "https://schema.org",
       "@type": "Article",
-      "headline": "How to Connect WhatsApp to Google Gemini",
-      "description": "Build a WhatsApp chatbot powered by Google Gemini using whatsmeow-node and the Google GenAI SDK. Includes conversation history and typing indicators.",
+      "headline": "Como Conectar o WhatsApp ao Google Gemini",
+      "description": "Crie um chatbot de WhatsApp com Google Gemini usando whatsmeow-node e o SDK Google GenAI. Inclui histórico de conversas e indicadores de digitação.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/connect-to-gemini.png",
       "author": {"@type": "Organization", "name": "whatsmeow-node", "url": "https://nicastelo.github.io/whatsmeow-node/"},
       "publisher": {"@type": "Organization", "name": "whatsmeow-node", "logo": {"@type": "ImageObject", "url": "https://nicastelo.github.io/whatsmeow-node/img/image.png"}}

--- a/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/connect-to-gemini.md
+++ b/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/connect-to-gemini.md
@@ -1,0 +1,231 @@
+---
+title: "Como Conectar o WhatsApp ao Google Gemini"
+sidebar_label: Conectar ao Gemini
+sidebar_position: 14
+description: "Crie um chatbot de WhatsApp com Google Gemini usando whatsmeow-node e o SDK Google GenAI. Inclui histórico de conversas e indicadores de digitação."
+keywords: [conectar whatsapp gemini, bot whatsapp gemini, bot whatsapp google ai nodejs, integração gemini whatsapp, whatsapp gemini typescript]
+---
+
+import Head from '@docusaurus/Head';
+import {RelatedGuides} from '@site/src/components/RelatedGuides';
+
+<Head>
+  <meta property="og:image" content="https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/connect-to-gemini.png" />
+  <meta name="twitter:image" content="https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/connect-to-gemini.png" />
+  <script type="application/ld+json">
+    {JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "HowTo",
+      "name": "How to Connect WhatsApp to Google Gemini",
+      "description": "Build a WhatsApp chatbot powered by Google Gemini using whatsmeow-node and the Google GenAI SDK. Includes conversation history and typing indicators.",
+      "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/connect-to-gemini.png",
+      "step": [
+        {"@type": "HowToStep", "name": "Set Up Both Clients", "text": "Initialize WhatsmeowClient with createClient() and Google GenAI with new GoogleGenAI()."},
+        {"@type": "HowToStep", "name": "Handle Incoming Messages", "text": "Listen for the message event, skip own messages, show typing, and extract text."},
+        {"@type": "HowToStep", "name": "Send to Gemini", "text": "Call ai.models.generateContent() with the user message and send the response back via sendMessage."},
+        {"@type": "HowToStep", "name": "Add Conversation History", "text": "Use Gemini's multi-turn chat feature to maintain conversation context per user."}
+      ]
+    })}
+  </script>
+  <script type="application/ld+json">
+    {JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "Article",
+      "headline": "How to Connect WhatsApp to Google Gemini",
+      "description": "Build a WhatsApp chatbot powered by Google Gemini using whatsmeow-node and the Google GenAI SDK. Includes conversation history and typing indicators.",
+      "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/connect-to-gemini.png",
+      "author": {"@type": "Organization", "name": "whatsmeow-node", "url": "https://nicastelo.github.io/whatsmeow-node/"},
+      "publisher": {"@type": "Organization", "name": "whatsmeow-node", "logo": {"@type": "ImageObject", "url": "https://nicastelo.github.io/whatsmeow-node/img/image.png"}}
+    })}
+  </script>
+</Head>
+
+![Como Conectar o WhatsApp ao Google Gemini](/img/guides/pt-BR/connect-to-gemini.png)
+![Como Conectar o WhatsApp ao Google Gemini](/img/guides/pt-BR/connect-to-gemini-light.png)
+
+# Como Conectar o WhatsApp ao Google Gemini
+
+Combine o whatsmeow-node com o SDK Google GenAI para criar um chatbot de WhatsApp com Gemini. As mensagens chegam pelo WhatsApp, são enviadas para o Gemini para gerar uma resposta, e a resposta volta para o usuário — com indicadores de digitação enquanto o modelo pensa.
+
+## Pré-requisitos
+
+- Uma sessão pareada do whatsmeow-node ([Como Parear](pair-whatsapp))
+- Uma chave de API do Google AI (defina como variável de ambiente `GEMINI_API_KEY`) — obtenha uma em [ai.google.dev](https://ai.google.dev/)
+- O SDK Google GenAI: `npm install @google/genai`
+
+## Passo 1: Configurar os Dois Clients
+
+```typescript
+import { createClient } from "@whatsmeow-node/whatsmeow-node";
+import { GoogleGenAI } from "@google/genai";
+
+const client = createClient({ store: "session.db" });
+const ai = new GoogleGenAI({ apiKey: process.env.GEMINI_API_KEY });
+
+const SYSTEM_PROMPT = "You are a helpful WhatsApp assistant. Keep responses concise — under 500 characters when possible, since this is a chat interface.";
+```
+
+## Passo 2: Tratar Mensagens Recebidas
+
+```typescript
+client.on("message", async ({ info, message }) => {
+  if (info.isFromMe) return;
+
+  const text =
+    (message.conversation as string) ??
+    (message.extendedTextMessage as { text?: string } | undefined)?.text;
+  if (!text) return;
+
+  await client.sendChatPresence(info.chat, "composing");
+
+  const reply = await askGemini(info.sender, text);
+  await client.sendMessage(info.chat, { conversation: reply });
+});
+```
+
+## Passo 3: Enviar para o Gemini
+
+```typescript
+async function askGemini(userJid: string, userMessage: string): Promise<string> {
+  const response = await ai.models.generateContent({
+    model: "gemini-2.5-flash",
+    contents: userMessage,
+    config: {
+      systemInstruction: SYSTEM_PROMPT,
+    },
+  });
+
+  return response.text ?? "I couldn't generate a response.";
+}
+```
+
+## Passo 4: Adicionar Histórico de Conversas
+
+O Gemini suporta chat multi-turno via a API `chats.create()`. Armazene uma sessão de chat por usuário:
+
+```typescript
+import type { Chat } from "@google/genai";
+
+const chats = new Map<string, Chat>();
+
+function getChat(userJid: string): Chat {
+  let chat = chats.get(userJid);
+  if (!chat) {
+    chat = ai.chats.create({
+      model: "gemini-2.5-flash",
+      config: {
+        systemInstruction: SYSTEM_PROMPT,
+      },
+    });
+    chats.set(userJid, chat);
+  }
+  return chat;
+}
+
+async function askGemini(userJid: string, userMessage: string): Promise<string> {
+  const chat = getChat(userJid);
+  const response = await chat.sendMessage({ message: userMessage });
+  return response.text ?? "I couldn't generate a response.";
+}
+```
+
+## Exemplo Completo
+
+```typescript
+import { createClient } from "@whatsmeow-node/whatsmeow-node";
+import { GoogleGenAI } from "@google/genai";
+import type { Chat } from "@google/genai";
+
+const client = createClient({ store: "session.db" });
+const ai = new GoogleGenAI({ apiKey: process.env.GEMINI_API_KEY });
+
+const SYSTEM_PROMPT =
+  "You are a helpful WhatsApp assistant. Keep responses concise — under 500 characters when possible, since this is a chat interface.";
+
+const chats = new Map<string, Chat>();
+
+function getChat(userJid: string): Chat {
+  let chat = chats.get(userJid);
+  if (!chat) {
+    chat = ai.chats.create({
+      model: "gemini-2.5-flash",
+      config: {
+        systemInstruction: SYSTEM_PROMPT,
+      },
+    });
+    chats.set(userJid, chat);
+  }
+  return chat;
+}
+
+async function askGemini(userJid: string, userMessage: string): Promise<string> {
+  const chat = getChat(userJid);
+  const response = await chat.sendMessage({ message: userMessage });
+  return response.text ?? "I couldn't generate a response.";
+}
+
+client.on("message", async ({ info, message }) => {
+  if (info.isFromMe) return;
+
+  const text =
+    (message.conversation as string) ??
+    (message.extendedTextMessage as { text?: string } | undefined)?.text;
+  if (!text) return;
+
+  console.log(`${info.pushName}: ${text}`);
+  await client.sendChatPresence(info.chat, "composing");
+
+  try {
+    const reply = await askGemini(info.sender, text);
+    await client.sendMessage(info.chat, { conversation: reply });
+    console.log(`→ ${reply.slice(0, 80)}...`);
+  } catch (err) {
+    console.error("Gemini API error:", err);
+    await client.sendMessage(info.chat, {
+      conversation: "Sorry, I'm having trouble right now. Try again in a moment.",
+    });
+  }
+});
+
+client.on("logged_out", ({ reason }) => {
+  console.error(`Logged out: ${reason}`);
+  client.close();
+  process.exit(1);
+});
+
+async function main() {
+  const { jid } = await client.init();
+  if (!jid) {
+    console.error("Not paired! See: How to Pair WhatsApp");
+    process.exit(1);
+  }
+  await client.connect();
+  await client.sendPresence("available");
+  console.log("Gemini bot is online!");
+
+  process.on("SIGINT", async () => {
+    await client.sendPresence("unavailable");
+    await client.disconnect();
+    client.close();
+    process.exit(0);
+  });
+}
+
+main().catch(console.error);
+```
+
+## Erros Comuns
+
+:::warning Loops de eco
+Sempre verifique `info.isFromMe` primeiro. Sem isso, o bot envia uma mensagem, vê a própria mensagem, manda para o Gemini e responde de novo — para sempre.
+:::
+
+:::warning Exposição da chave de API
+Nunca coloque sua chave de API diretamente no código. Use variáveis de ambiente (`GEMINI_API_KEY`) ou um arquivo `.env` (adicionado ao `.gitignore`).
+:::
+
+:::warning Histórico de chat em memória
+Os objetos `Chat` são armazenados em um `Map` e perdidos ao reiniciar. Para persistência, salve o histórico de conversas em um banco de dados e recrie os chats com a opção `history`.
+:::
+
+<RelatedGuides slugs={["connect-to-ai", "connect-to-chatgpt", "connect-to-ollama", "connect-to-deepseek"]} />

--- a/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/connect-to-ollama.md
+++ b/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/connect-to-ollama.md
@@ -16,14 +16,14 @@ import {RelatedGuides} from '@site/src/components/RelatedGuides';
     {JSON.stringify({
       "@context": "https://schema.org",
       "@type": "HowTo",
-      "name": "How to Connect WhatsApp to Ollama (Local AI)",
-      "description": "Build a WhatsApp chatbot powered by a local AI model using whatsmeow-node and Ollama. No API key needed — runs entirely on your machine.",
+      "name": "Como Conectar o WhatsApp ao Ollama (IA Local)",
+      "description": "Crie um chatbot de WhatsApp com IA local usando whatsmeow-node e Ollama. Sem chave de API — roda inteiramente na sua máquina.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/connect-to-ollama.png",
       "step": [
-        {"@type": "HowToStep", "name": "Install Ollama and Pull a Model", "text": "Install Ollama from ollama.com and pull a model like llama3.2 or gemma3."},
-        {"@type": "HowToStep", "name": "Set Up Both Clients", "text": "Initialize WhatsmeowClient with createClient() and Ollama client with new Ollama()."},
-        {"@type": "HowToStep", "name": "Handle Incoming Messages", "text": "Listen for the message event, skip own messages, show typing, and extract text."},
-        {"@type": "HowToStep", "name": "Send to Ollama", "text": "Call ollama.chat() with the user message and send the response back via sendMessage."}
+        {"@type": "HowToStep", "name": "Instalar o Ollama e Baixar um Modelo", "text": "Instale o Ollama a partir de ollama.com e baixe um modelo como llama3.2 ou gemma3."},
+        {"@type": "HowToStep", "name": "Configurar os Dois Clients", "text": "Inicialize o WhatsmeowClient com createClient() e o client do Ollama com new Ollama()."},
+        {"@type": "HowToStep", "name": "Tratar Mensagens Recebidas", "text": "Escute o evento message, ignore mensagens próprias, mostre digitação e extraia o texto."},
+        {"@type": "HowToStep", "name": "Enviar para o Ollama", "text": "Chame ollama.chat() com a mensagem do usuário e envie a resposta de volta via sendMessage."}
       ]
     })}
   </script>
@@ -31,8 +31,8 @@ import {RelatedGuides} from '@site/src/components/RelatedGuides';
     {JSON.stringify({
       "@context": "https://schema.org",
       "@type": "Article",
-      "headline": "How to Connect WhatsApp to Ollama (Local AI)",
-      "description": "Build a WhatsApp chatbot powered by a local AI model using whatsmeow-node and Ollama. No API key needed — runs entirely on your machine.",
+      "headline": "Como Conectar o WhatsApp ao Ollama (IA Local)",
+      "description": "Crie um chatbot de WhatsApp com IA local usando whatsmeow-node e Ollama. Sem chave de API — roda inteiramente na sua máquina.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/connect-to-ollama.png",
       "author": {"@type": "Organization", "name": "whatsmeow-node", "url": "https://nicastelo.github.io/whatsmeow-node/"},
       "publisher": {"@type": "Organization", "name": "whatsmeow-node", "logo": {"@type": "ImageObject", "url": "https://nicastelo.github.io/whatsmeow-node/img/image.png"}}

--- a/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/connect-to-ollama.md
+++ b/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/connect-to-ollama.md
@@ -1,0 +1,250 @@
+---
+title: "Como Conectar o WhatsApp ao Ollama (IA Local)"
+sidebar_label: Conectar ao Ollama
+sidebar_position: 16
+description: "Crie um chatbot de WhatsApp com IA local usando whatsmeow-node e Ollama. Sem chave de API — roda inteiramente na sua máquina."
+keywords: [conectar whatsapp ollama, bot whatsapp ia local, bot whatsapp ollama nodejs, bot whatsapp llama, whatsapp llm local, whatsapp ia self hosted]
+---
+
+import Head from '@docusaurus/Head';
+import {RelatedGuides} from '@site/src/components/RelatedGuides';
+
+<Head>
+  <meta property="og:image" content="https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/connect-to-ollama.png" />
+  <meta name="twitter:image" content="https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/connect-to-ollama.png" />
+  <script type="application/ld+json">
+    {JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "HowTo",
+      "name": "How to Connect WhatsApp to Ollama (Local AI)",
+      "description": "Build a WhatsApp chatbot powered by a local AI model using whatsmeow-node and Ollama. No API key needed — runs entirely on your machine.",
+      "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/connect-to-ollama.png",
+      "step": [
+        {"@type": "HowToStep", "name": "Install Ollama and Pull a Model", "text": "Install Ollama from ollama.com and pull a model like llama3.2 or gemma3."},
+        {"@type": "HowToStep", "name": "Set Up Both Clients", "text": "Initialize WhatsmeowClient with createClient() and Ollama client with new Ollama()."},
+        {"@type": "HowToStep", "name": "Handle Incoming Messages", "text": "Listen for the message event, skip own messages, show typing, and extract text."},
+        {"@type": "HowToStep", "name": "Send to Ollama", "text": "Call ollama.chat() with the user message and send the response back via sendMessage."}
+      ]
+    })}
+  </script>
+  <script type="application/ld+json">
+    {JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "Article",
+      "headline": "How to Connect WhatsApp to Ollama (Local AI)",
+      "description": "Build a WhatsApp chatbot powered by a local AI model using whatsmeow-node and Ollama. No API key needed — runs entirely on your machine.",
+      "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/connect-to-ollama.png",
+      "author": {"@type": "Organization", "name": "whatsmeow-node", "url": "https://nicastelo.github.io/whatsmeow-node/"},
+      "publisher": {"@type": "Organization", "name": "whatsmeow-node", "logo": {"@type": "ImageObject", "url": "https://nicastelo.github.io/whatsmeow-node/img/image.png"}}
+    })}
+  </script>
+</Head>
+
+![Como Conectar o WhatsApp ao Ollama (IA Local)](/img/guides/pt-BR/connect-to-ollama.png)
+![Como Conectar o WhatsApp ao Ollama (IA Local)](/img/guides/pt-BR/connect-to-ollama-light.png)
+
+# Como Conectar o WhatsApp ao Ollama (IA Local)
+
+Rode seu chatbot de WhatsApp inteiramente na sua própria máquina — sem chaves de API, sem custos de nuvem, sem dados saindo da sua rede. O Ollama facilita rodar modelos open-source como Llama, Gemma e Mistral localmente.
+
+## Pré-requisitos
+
+- Uma sessão pareada do whatsmeow-node ([Como Parear](pair-whatsapp))
+- [Ollama](https://ollama.com/) instalado e rodando
+- Um modelo baixado: `ollama pull llama3.2`
+- O SDK do Ollama: `npm install ollama`
+
+## Passo 1: Baixar um Modelo
+
+```bash
+# Install Ollama from https://ollama.com, then:
+ollama pull llama3.2
+```
+
+Outras boas opções para chat:
+- `gemma3` — modelo aberto do Google, rápido e capaz
+- `mistral` — forte para o seu tamanho
+- `llama3.2:1b` — menor Llama, respostas mais rápidas
+
+## Passo 2: Configurar os Dois Clients
+
+```typescript
+import { createClient } from "@whatsmeow-node/whatsmeow-node";
+import { Ollama } from "ollama";
+
+const client = createClient({ store: "session.db" });
+const ollama = new Ollama({ host: "http://localhost:11434" });
+
+const MODEL = "llama3.2";
+const SYSTEM_PROMPT = "You are a helpful WhatsApp assistant. Keep responses concise — under 500 characters when possible, since this is a chat interface.";
+```
+
+## Passo 3: Tratar Mensagens Recebidas
+
+```typescript
+client.on("message", async ({ info, message }) => {
+  if (info.isFromMe) return;
+
+  const text =
+    (message.conversation as string) ??
+    (message.extendedTextMessage as { text?: string } | undefined)?.text;
+  if (!text) return;
+
+  await client.sendChatPresence(info.chat, "composing");
+
+  const reply = await askOllama(info.sender, text);
+  await client.sendMessage(info.chat, { conversation: reply });
+});
+```
+
+## Passo 4: Enviar para o Ollama
+
+```typescript
+async function askOllama(userJid: string, userMessage: string): Promise<string> {
+  const response = await ollama.chat({
+    model: MODEL,
+    messages: [
+      { role: "system", content: SYSTEM_PROMPT },
+      { role: "user", content: userMessage },
+    ],
+  });
+
+  return response.message.content;
+}
+```
+
+## Passo 5: Adicionar Histórico de Conversas
+
+```typescript
+import type { Message } from "ollama";
+
+const conversations = new Map<string, Message[]>();
+const MAX_HISTORY = 20;
+
+async function askOllama(userJid: string, userMessage: string): Promise<string> {
+  const history = conversations.get(userJid) ?? [];
+  history.push({ role: "user", content: userMessage });
+
+  if (history.length > MAX_HISTORY) {
+    history.splice(0, history.length - MAX_HISTORY);
+  }
+
+  const response = await ollama.chat({
+    model: MODEL,
+    messages: [{ role: "system", content: SYSTEM_PROMPT }, ...history],
+  });
+
+  const reply = response.message.content;
+  history.push({ role: "assistant", content: reply });
+  conversations.set(userJid, history);
+
+  return reply;
+}
+```
+
+## Exemplo Completo
+
+```typescript
+import { createClient } from "@whatsmeow-node/whatsmeow-node";
+import { Ollama } from "ollama";
+import type { Message } from "ollama";
+
+const client = createClient({ store: "session.db" });
+const ollama = new Ollama({ host: "http://localhost:11434" });
+
+const MODEL = "llama3.2";
+const SYSTEM_PROMPT =
+  "You are a helpful WhatsApp assistant. Keep responses concise — under 500 characters when possible, since this is a chat interface.";
+
+const conversations = new Map<string, Message[]>();
+const MAX_HISTORY = 20;
+
+async function askOllama(userJid: string, userMessage: string): Promise<string> {
+  const history = conversations.get(userJid) ?? [];
+  history.push({ role: "user", content: userMessage });
+
+  if (history.length > MAX_HISTORY) {
+    history.splice(0, history.length - MAX_HISTORY);
+  }
+
+  const response = await ollama.chat({
+    model: MODEL,
+    messages: [{ role: "system", content: SYSTEM_PROMPT }, ...history],
+  });
+
+  const reply = response.message.content;
+  history.push({ role: "assistant", content: reply });
+  conversations.set(userJid, history);
+
+  return reply;
+}
+
+client.on("message", async ({ info, message }) => {
+  if (info.isFromMe) return;
+
+  const text =
+    (message.conversation as string) ??
+    (message.extendedTextMessage as { text?: string } | undefined)?.text;
+  if (!text) return;
+
+  console.log(`${info.pushName}: ${text}`);
+  await client.sendChatPresence(info.chat, "composing");
+
+  try {
+    const reply = await askOllama(info.sender, text);
+    await client.sendMessage(info.chat, { conversation: reply });
+    console.log(`→ ${reply.slice(0, 80)}...`);
+  } catch (err) {
+    console.error("Ollama error:", err);
+    await client.sendMessage(info.chat, {
+      conversation: "Sorry, I'm having trouble right now. Make sure Ollama is running.",
+    });
+  }
+});
+
+client.on("logged_out", ({ reason }) => {
+  console.error(`Logged out: ${reason}`);
+  client.close();
+  process.exit(1);
+});
+
+async function main() {
+  const { jid } = await client.init();
+  if (!jid) {
+    console.error("Not paired! See: How to Pair WhatsApp");
+    process.exit(1);
+  }
+  await client.connect();
+  await client.sendPresence("available");
+  console.log(`Ollama bot is online! (model: ${MODEL})`);
+
+  process.on("SIGINT", async () => {
+    await client.sendPresence("unavailable");
+    await client.disconnect();
+    client.close();
+    process.exit(0);
+  });
+}
+
+main().catch(console.error);
+```
+
+## Erros Comuns
+
+:::warning O Ollama precisa estar rodando
+Certifique-se de que o servidor do Ollama está rodando (`ollama serve`) antes de iniciar o bot. Se não estiver rodando, todas as requisições vão falhar.
+:::
+
+:::warning Tempo de resposta depende do hardware
+Modelos locais rodam na sua CPU/GPU. Modelos menores como `llama3.2:1b` respondem em 1-3 segundos em hardware moderno. Modelos maiores podem levar 10+ segundos — o indicador de digitação mantém o usuário informado enquanto espera.
+:::
+
+:::warning Loops de eco
+Sempre verifique `info.isFromMe` primeiro. Sem isso, o bot responde às próprias mensagens para sempre.
+:::
+
+:::warning O modelo precisa ser baixado antes
+Execute `ollama pull llama3.2` antes de iniciar o bot. Se o modelo não estiver baixado, as requisições vão falhar.
+:::
+
+<RelatedGuides slugs={["connect-to-ai", "connect-to-chatgpt", "connect-to-gemini", "connect-to-deepseek"]} />

--- a/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/download-media.md
+++ b/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/download-media.md
@@ -19,10 +19,10 @@ import Head from '@docusaurus/Head';
       "description": "Baixe e salve imagens, vídeos, áudios, documentos e stickers do WhatsApp no disco com Node.js usando whatsmeow-node.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/download-media.png",
       "step": [
-        {"@type": "HowToStep", "name": "Listen for Incoming Messages", "text": "Subscribe to the message event and filter for media messages."},
-        {"@type": "HowToStep", "name": "Detect the Media Type", "text": "Check for imageMessage, videoMessage, audioMessage, documentMessage, or stickerMessage fields."},
-        {"@type": "HowToStep", "name": "Download with downloadAny()", "text": "Call downloadAny(message) to decrypt and save media to a temporary file."},
-        {"@type": "HowToStep", "name": "Save to a Permanent Location", "text": "Copy the temp file to a permanent directory using fs.copyFile()."}
+        {"@type": "HowToStep", "name": "Escutar Mensagens Recebidas", "text": "Inscreva-se no evento message e filtre por mensagens de mídia."},
+        {"@type": "HowToStep", "name": "Detectar o Tipo de Mídia", "text": "Verifique os campos imageMessage, videoMessage, audioMessage, documentMessage ou stickerMessage."},
+        {"@type": "HowToStep", "name": "Baixar com downloadAny()", "text": "Chame downloadAny(message) para descriptografar e salvar a mídia em um arquivo temporário."},
+        {"@type": "HowToStep", "name": "Salvar em um Local Permanente", "text": "Copie o arquivo temporário para um diretório permanente usando fs.copyFile()."}
       ]
     })}
   </script>

--- a/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/forward-messages.md
+++ b/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/forward-messages.md
@@ -1,0 +1,305 @@
+---
+title: "Como Encaminhar Mensagens do WhatsApp Programaticamente"
+sidebar_label: Encaminhar Mensagens
+sidebar_position: 20
+description: "Encaminhe mensagens entre chats do WhatsApp programaticamente com Node.js — texto, mídia e mensagens de grupo usando whatsmeow-node."
+keywords: [encaminhar mensagens whatsapp api, whatsapp encaminhar mensagem nodejs, bot encaminhamento whatsapp, encaminhar mensagens whatsapp programaticamente, bot relay whatsapp]
+---
+
+import Head from '@docusaurus/Head';
+import {RelatedGuides} from '@site/src/components/RelatedGuides';
+
+<Head>
+  <meta property="og:image" content="https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/forward-messages.png" />
+  <meta name="twitter:image" content="https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/forward-messages.png" />
+  <script type="application/ld+json">
+    {JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "HowTo",
+      "name": "How to Forward WhatsApp Messages Programmatically",
+      "description": "Forward WhatsApp messages between chats programmatically with Node.js — text, media, and group messages using whatsmeow-node.",
+      "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/forward-messages.png",
+      "step": [
+        {"@type": "HowToStep", "name": "Listen for Messages", "text": "Subscribe to the message event and filter for messages you want to forward."},
+        {"@type": "HowToStep", "name": "Forward Text Messages", "text": "Use sendRawMessage with the original message content and isForwarded flag in contextInfo."},
+        {"@type": "HowToStep", "name": "Forward Media Messages", "text": "Pass the original media message directly — no need to re-upload."},
+        {"@type": "HowToStep", "name": "Build a Relay Bot", "text": "Forward messages between a group and a private chat, or between multiple groups."}
+      ]
+    })}
+  </script>
+  <script type="application/ld+json">
+    {JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "Article",
+      "headline": "How to Forward WhatsApp Messages Programmatically",
+      "description": "Forward WhatsApp messages between chats programmatically with Node.js — text, media, and group messages using whatsmeow-node.",
+      "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/forward-messages.png",
+      "author": {"@type": "Organization", "name": "whatsmeow-node", "url": "https://nicastelo.github.io/whatsmeow-node/"},
+      "publisher": {"@type": "Organization", "name": "whatsmeow-node", "logo": {"@type": "ImageObject", "url": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/forward-messages.png"}}
+    })}
+  </script>
+</Head>
+
+![Como Encaminhar Mensagens do WhatsApp Programaticamente](/img/guides/pt-BR/forward-messages.png)
+![Como Encaminhar Mensagens do WhatsApp Programaticamente](/img/guides/pt-BR/forward-messages-light.png)
+
+# Como Encaminhar Mensagens do WhatsApp Programaticamente
+
+Encaminhe mensagens entre chats do WhatsApp usando `sendRawMessage()`. Você pode encaminhar texto, mídia, enquetes e qualquer outro tipo de mensagem — com ou sem o rótulo "Encaminhada".
+
+## Pré-requisitos
+
+- Uma sessão pareada do whatsmeow-node ([Como Parear](pair-whatsapp))
+
+## Encaminhar uma Mensagem de Texto
+
+Para encaminhar uma mensagem recebida para outro chat, passe-a via `sendRawMessage` com a flag `isForwarded`:
+
+```typescript
+const targetJid = "5598765432@s.whatsapp.net";
+
+client.on("message", async ({ info, message }) => {
+  if (info.isFromMe) return;
+
+  const text =
+    (message.conversation as string) ??
+    (message.extendedTextMessage as { text?: string } | undefined)?.text;
+  if (!text) return;
+
+  // Forward as a new message with the "Forwarded" label
+  await client.sendRawMessage(targetJid, {
+    extendedTextMessage: {
+      text,
+      contextInfo: {
+        isForwarded: true,
+        forwardingScore: 1,
+      },
+    },
+  });
+});
+```
+
+A flag `isForwarded: true` exibe o rótulo "Encaminhada" na mensagem. O `forwardingScore` rastreia quantas vezes a mensagem foi encaminhada — o WhatsApp mostra "Encaminhada com frequência" quando atinge 4+.
+
+## Encaminhar Sem o Rótulo "Encaminhada"
+
+Para repassar uma mensagem sem o rótulo de encaminhamento, simplesmente envie como uma mensagem nova:
+
+```typescript
+// Send as if it's a new message — no forwarding label
+await client.sendMessage(targetJid, { conversation: text });
+```
+
+## Encaminhar Mensagens de Mídia
+
+Mensagens de mídia (imagens, vídeos, documentos) podem ser encaminhadas passando o conteúdo original da mensagem. A mídia já está hospedada nos servidores do WhatsApp, então não é necessário reenviar:
+
+```typescript
+client.on("message", async ({ info, message }) => {
+  if (info.isFromMe) return;
+
+  // Forward images
+  if (message.imageMessage) {
+    await client.sendRawMessage(targetJid, {
+      imageMessage: {
+        ...message.imageMessage,
+        contextInfo: {
+          isForwarded: true,
+          forwardingScore: 1,
+        },
+      },
+    });
+    return;
+  }
+
+  // Forward videos
+  if (message.videoMessage) {
+    await client.sendRawMessage(targetJid, {
+      videoMessage: {
+        ...message.videoMessage,
+        contextInfo: {
+          isForwarded: true,
+          forwardingScore: 1,
+        },
+      },
+    });
+    return;
+  }
+
+  // Forward documents
+  if (message.documentMessage) {
+    await client.sendRawMessage(targetJid, {
+      documentMessage: {
+        ...message.documentMessage,
+        contextInfo: {
+          isForwarded: true,
+          forwardingScore: 1,
+        },
+      },
+    });
+    return;
+  }
+});
+```
+
+## Encaminhar Qualquer Tipo de Mensagem
+
+Uma função genérica que encaminha qualquer mensagem detectando o tipo:
+
+```typescript
+const MESSAGE_TYPES = [
+  "conversation",
+  "extendedTextMessage",
+  "imageMessage",
+  "videoMessage",
+  "audioMessage",
+  "documentMessage",
+  "stickerMessage",
+  "contactMessage",
+  "locationMessage",
+  "pollCreationMessage",
+] as const;
+
+async function forwardMessage(
+  targetJid: string,
+  message: Record<string, unknown>,
+  showForwarded = true,
+) {
+  for (const type of MESSAGE_TYPES) {
+    if (!(type in message)) continue;
+
+    if (type === "conversation") {
+      // Simple text — wrap in extendedTextMessage for contextInfo support
+      await client.sendRawMessage(targetJid, {
+        extendedTextMessage: {
+          text: message.conversation as string,
+          ...(showForwarded && {
+            contextInfo: { isForwarded: true, forwardingScore: 1 },
+          }),
+        },
+      });
+    } else {
+      // Structured message — spread and add contextInfo
+      const content = message[type] as Record<string, unknown>;
+      await client.sendRawMessage(targetJid, {
+        [type]: {
+          ...content,
+          ...(showForwarded && {
+            contextInfo: {
+              ...(content.contextInfo as Record<string, unknown> ?? {}),
+              isForwarded: true,
+              forwardingScore: 1,
+            },
+          }),
+        },
+      });
+    }
+    return;
+  }
+}
+```
+
+## Criar um Bot Relay
+
+Encaminhe todas as mensagens de um grupo para outro:
+
+```typescript
+const SOURCE_GROUP = "120363XXXXX@g.us";
+const TARGET_GROUP = "120363YYYYY@g.us";
+
+client.on("message", async ({ info, message }) => {
+  if (info.isFromMe) return;
+  if (info.chat !== SOURCE_GROUP) return;
+
+  // Add sender attribution
+  const attribution = `[${info.pushName}]:\n`;
+
+  const text =
+    (message.conversation as string) ??
+    (message.extendedTextMessage as { text?: string } | undefined)?.text;
+
+  if (text) {
+    await client.sendMessage(TARGET_GROUP, {
+      conversation: `${attribution}${text}`,
+    });
+    return;
+  }
+
+  // Forward media with caption attribution
+  await forwardMessage(TARGET_GROUP, message);
+});
+```
+
+## Exemplo Completo
+
+Um bot relay que encaminha mensagens entre um chat privado e um grupo:
+
+```typescript
+import { createClient } from "@whatsmeow-node/whatsmeow-node";
+
+const client = createClient({ store: "session.db" });
+
+// Forward messages FROM this chat TO the group
+const PRIVATE_CHAT = "5512345678@s.whatsapp.net";
+const GROUP_CHAT = "120363XXXXX@g.us";
+
+client.on("message", async ({ info, message }) => {
+  if (info.isFromMe) return;
+
+  const text =
+    (message.conversation as string) ??
+    (message.extendedTextMessage as { text?: string } | undefined)?.text;
+
+  // Private → Group
+  if (info.chat === PRIVATE_CHAT && text) {
+    await client.sendMessage(GROUP_CHAT, {
+      conversation: `[${info.pushName}]: ${text}`,
+    });
+    return;
+  }
+
+  // Group → Private
+  if (info.chat === GROUP_CHAT && text) {
+    await client.sendMessage(PRIVATE_CHAT, {
+      conversation: `[${info.pushName} in group]: ${text}`,
+    });
+    return;
+  }
+});
+
+async function main() {
+  const { jid } = await client.init();
+  if (!jid) {
+    console.error("Not paired!");
+    process.exit(1);
+  }
+  await client.connect();
+  await client.sendPresence("available");
+  console.log("Relay bot is online!");
+
+  process.on("SIGINT", async () => {
+    await client.sendPresence("unavailable");
+    await client.disconnect();
+    client.close();
+    process.exit(0);
+  });
+}
+
+main().catch(console.error);
+```
+
+## Erros Comuns
+
+:::warning Loops de eco
+Se você encaminha mensagens de um chat e também ouve o chat de destino, pode criar um loop infinito. Sempre verifique o chat de origem e ignore suas próprias mensagens.
+:::
+
+:::warning Expiração de mídia
+As URLs de mídia do WhatsApp expiram após algum tempo. Se você salvar uma mensagem e tentar encaminhá-la muito depois, a mídia pode não estar mais disponível. Encaminhe mídia rapidamente ou baixe-a primeiro com `downloadAny()`.
+:::
+
+:::warning Rate limiting
+Encaminhar muitas mensagens rapidamente vai atingir os rate limits do WhatsApp. Espaçe os envios, especialmente para operações de relay em massa. Veja [Rate Limiting](/docs/rate-limiting).
+:::
+
+<RelatedGuides slugs={["build-a-bot", "download-media", "automate-group-messages"]} />

--- a/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/forward-messages.md
+++ b/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/forward-messages.md
@@ -16,14 +16,14 @@ import {RelatedGuides} from '@site/src/components/RelatedGuides';
     {JSON.stringify({
       "@context": "https://schema.org",
       "@type": "HowTo",
-      "name": "How to Forward WhatsApp Messages Programmatically",
-      "description": "Forward WhatsApp messages between chats programmatically with Node.js — text, media, and group messages using whatsmeow-node.",
+      "name": "Como Encaminhar Mensagens do WhatsApp Programaticamente",
+      "description": "Encaminhe mensagens entre chats do WhatsApp programaticamente com Node.js — texto, mídia e mensagens de grupo usando whatsmeow-node.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/forward-messages.png",
       "step": [
-        {"@type": "HowToStep", "name": "Listen for Messages", "text": "Subscribe to the message event and filter for messages you want to forward."},
-        {"@type": "HowToStep", "name": "Forward Text Messages", "text": "Use sendRawMessage with the original message content and isForwarded flag in contextInfo."},
-        {"@type": "HowToStep", "name": "Forward Media Messages", "text": "Pass the original media message directly — no need to re-upload."},
-        {"@type": "HowToStep", "name": "Build a Relay Bot", "text": "Forward messages between a group and a private chat, or between multiple groups."}
+        {"@type": "HowToStep", "name": "Escutar Mensagens", "text": "Inscreva-se no evento message e filtre as mensagens que deseja encaminhar."},
+        {"@type": "HowToStep", "name": "Encaminhar Mensagens de Texto", "text": "Use sendRawMessage com o conteúdo original da mensagem e a flag isForwarded no contextInfo."},
+        {"@type": "HowToStep", "name": "Encaminhar Mensagens de Mídia", "text": "Passe a mensagem de mídia original diretamente — não é necessário fazer upload novamente."},
+        {"@type": "HowToStep", "name": "Criar um Bot Relay", "text": "Encaminhe mensagens entre um grupo e um chat privado, ou entre vários grupos."}
       ]
     })}
   </script>
@@ -31,8 +31,8 @@ import {RelatedGuides} from '@site/src/components/RelatedGuides';
     {JSON.stringify({
       "@context": "https://schema.org",
       "@type": "Article",
-      "headline": "How to Forward WhatsApp Messages Programmatically",
-      "description": "Forward WhatsApp messages between chats programmatically with Node.js — text, media, and group messages using whatsmeow-node.",
+      "headline": "Como Encaminhar Mensagens do WhatsApp Programaticamente",
+      "description": "Encaminhe mensagens entre chats do WhatsApp programaticamente com Node.js — texto, mídia e mensagens de grupo usando whatsmeow-node.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/forward-messages.png",
       "author": {"@type": "Organization", "name": "whatsmeow-node", "url": "https://nicastelo.github.io/whatsmeow-node/"},
       "publisher": {"@type": "Organization", "name": "whatsmeow-node", "logo": {"@type": "ImageObject", "url": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/forward-messages.png"}}

--- a/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/integrate-chatwoot.md
+++ b/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/integrate-chatwoot.md
@@ -1,0 +1,257 @@
+---
+title: "Como Usar o whatsmeow-node com Chatwoot"
+sidebar_label: Integração com Chatwoot
+sidebar_position: 23
+description: "Conecte o whatsmeow-node ao Chatwoot como canal WhatsApp — receba e responda mensagens do WhatsApp pelo painel de agentes do Chatwoot sem a Cloud API oficial."
+keywords: [chatwoot whatsapp, chatwoot whatsmeow, chatwoot whatsapp grátis, chatwoot whatsapp sem cloud api, chatwoot integração whatsapp, chatwoot whatsapp nodejs]
+---
+
+import Head from '@docusaurus/Head';
+import {RelatedGuides} from '@site/src/components/RelatedGuides';
+
+<Head>
+  <meta property="og:image" content="https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/integrate-chatwoot.png" />
+  <meta name="twitter:image" content="https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/integrate-chatwoot.png" />
+  <script type="application/ld+json">
+    {JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "HowTo",
+      "name": "How to Use whatsmeow-node with Chatwoot",
+      "description": "Connect whatsmeow-node to Chatwoot as a WhatsApp channel — receive and reply to WhatsApp messages from the Chatwoot agent dashboard without the official Cloud API.",
+      "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/integrate-chatwoot.png",
+      "step": [
+        {"@type": "HowToStep", "name": "Create a Chatwoot API Channel", "text": "Set up an API channel in Chatwoot to receive messages via webhook and send via API."},
+        {"@type": "HowToStep", "name": "Build the whatsmeow-node Bridge", "text": "Create a service that forwards WhatsApp messages to Chatwoot and Chatwoot replies to WhatsApp."},
+        {"@type": "HowToStep", "name": "Forward Messages to Chatwoot", "text": "POST incoming WhatsApp messages to Chatwoot's API as incoming messages on the channel."},
+        {"@type": "HowToStep", "name": "Handle Chatwoot Outgoing Webhooks", "text": "Listen for Chatwoot's message_created webhook and send agent replies via whatsmeow-node."}
+      ]
+    })}
+  </script>
+  <script type="application/ld+json">
+    {JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "Article",
+      "headline": "How to Use whatsmeow-node with Chatwoot",
+      "description": "Connect whatsmeow-node to Chatwoot as a WhatsApp channel — receive and reply to WhatsApp messages from the Chatwoot agent dashboard without the official Cloud API.",
+      "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/integrate-chatwoot.png",
+      "author": {"@type": "Organization", "name": "whatsmeow-node", "url": "https://nicastelo.github.io/whatsmeow-node/"},
+      "publisher": {"@type": "Organization", "name": "whatsmeow-node", "logo": {"@type": "ImageObject", "url": "https://nicastelo.github.io/whatsmeow-node/img/image.png"}}
+    })}
+  </script>
+</Head>
+
+![Como Usar o whatsmeow-node com Chatwoot](/img/guides/pt-BR/integrate-chatwoot.png)
+![Como Usar o whatsmeow-node com Chatwoot](/img/guides/pt-BR/integrate-chatwoot-light.png)
+
+# Como Usar o whatsmeow-node com Chatwoot
+
+O [Chatwoot](https://www.chatwoot.com) é uma plataforma open-source de suporte ao cliente — como Intercom ou Zendesk. Sua integração nativa com WhatsApp requer a Cloud API oficial (verificação Meta Business, cobrança por mensagem). Com o whatsmeow-node e o canal API do Chatwoot, você pode conectar o WhatsApp de graça.
+
+## Como Funciona
+
+```
+WhatsApp User
+  ↕
+whatsmeow-node Bridge (Express)
+  ↕ Chatwoot API
+Chatwoot Dashboard (agents reply here)
+```
+
+A ponte fica entre o WhatsApp e o Chatwoot:
+- **Entrada**: mensagem do WhatsApp, whatsmeow-node, Chatwoot API (cria conversa)
+- **Saída**: agente responde no Chatwoot, webhook, ponte, whatsmeow-node, WhatsApp
+
+## Pré-requisitos
+
+- Uma sessão pareada do whatsmeow-node ([Como Parear](pair-whatsapp))
+- Chatwoot rodando (self-hosted ou cloud)
+- Express: `npm install express`
+
+## Passo 1: Criar um Canal API no Chatwoot
+
+1. No Chatwoot, vá em **Settings, Inboxes, Add Inbox**
+2. Selecione **API** como tipo de canal
+3. Nomeie como "WhatsApp" e salve
+4. Anote o **Inbox ID** e gere um **API access token** em Settings, Account Settings
+
+Defina como variáveis de ambiente:
+
+```bash
+CHATWOOT_URL=http://localhost:3001        # Your Chatwoot URL
+CHATWOOT_API_TOKEN=your_api_token
+CHATWOOT_ACCOUNT_ID=1
+CHATWOOT_INBOX_ID=1
+```
+
+## Passo 2: Configurar o Webhook do Chatwoot
+
+No Chatwoot, vá em **Settings, Integrations, Webhooks**:
+- **URL**: `http://localhost:3000/chatwoot/webhook` (seu servidor ponte)
+- **Events**: Selecione `message_created`
+
+Isso configura o Chatwoot para fazer POST das respostas dos agentes para a sua ponte.
+
+## Passo 3: Construir a Ponte
+
+```typescript
+import { createClient } from "@whatsmeow-node/whatsmeow-node";
+import express from "express";
+
+const client = createClient({ store: "session.db" });
+const app = express();
+app.use(express.json());
+
+const CHATWOOT_URL = process.env.CHATWOOT_URL!;
+const CHATWOOT_API_TOKEN = process.env.CHATWOOT_API_TOKEN!;
+const CHATWOOT_ACCOUNT_ID = process.env.CHATWOOT_ACCOUNT_ID!;
+const CHATWOOT_INBOX_ID = process.env.CHATWOOT_INBOX_ID!;
+
+// Map WhatsApp JID → Chatwoot contact ID + conversation ID
+const contactMap = new Map<string, { contactId: number; conversationId: number }>();
+
+// --- Helper: Chatwoot API call ---
+async function chatwootAPI(path: string, method: string, body?: unknown) {
+  const res = await fetch(`${CHATWOOT_URL}/api/v1/accounts/${CHATWOOT_ACCOUNT_ID}${path}`, {
+    method,
+    headers: {
+      "Content-Type": "application/json",
+      api_access_token: CHATWOOT_API_TOKEN,
+    },
+    ...(body && { body: JSON.stringify(body) }),
+  });
+  return res.json();
+}
+
+// --- Find or create Chatwoot contact ---
+async function getOrCreateContact(jid: string, name: string) {
+  const cached = contactMap.get(jid);
+  if (cached) return cached;
+
+  const phone = jid.split("@")[0];
+
+  // Search for existing contact
+  const search = await chatwootAPI(`/contacts/search?q=${phone}`, "GET");
+  let contactId: number;
+
+  if (search.payload?.length > 0) {
+    contactId = search.payload[0].id;
+  } else {
+    // Create new contact
+    const created = await chatwootAPI("/contacts", "POST", {
+      name: name || phone,
+      phone_number: `+${phone}`,
+      inbox_id: CHATWOOT_INBOX_ID,
+    });
+    contactId = created.payload?.contact?.id ?? created.id;
+  }
+
+  // Find or create conversation
+  const convos = await chatwootAPI(`/contacts/${contactId}/conversations`, "GET");
+  let conversationId: number;
+
+  const openConvo = convos.payload?.find(
+    (c: { inbox_id: number; status: string }) =>
+      c.inbox_id === Number(CHATWOOT_INBOX_ID) && c.status !== "resolved",
+  );
+
+  if (openConvo) {
+    conversationId = openConvo.id;
+  } else {
+    const created = await chatwootAPI("/conversations", "POST", {
+      contact_id: contactId,
+      inbox_id: CHATWOOT_INBOX_ID,
+    });
+    conversationId = created.id;
+  }
+
+  const mapping = { contactId, conversationId };
+  contactMap.set(jid, mapping);
+  return mapping;
+}
+
+// --- Forward WhatsApp messages to Chatwoot ---
+client.on("message", async ({ info, message }) => {
+  if (info.isFromMe || info.isGroup) return;
+
+  const text =
+    (message.conversation as string) ??
+    (message.extendedTextMessage as { text?: string } | undefined)?.text;
+  if (!text) return;
+
+  try {
+    const { conversationId } = await getOrCreateContact(info.sender, info.pushName);
+
+    await chatwootAPI(`/conversations/${conversationId}/messages`, "POST", {
+      content: text,
+      message_type: "incoming",
+    });
+  } catch (err) {
+    console.error("Failed to forward to Chatwoot:", err);
+  }
+});
+
+// --- Handle Chatwoot agent replies ---
+app.post("/chatwoot/webhook", async (req, res) => {
+  const { event, message_type, conversation, content } = req.body;
+
+  // Only handle outgoing messages from agents
+  if (event !== "message_created" || message_type !== "outgoing") {
+    return res.sendStatus(200);
+  }
+
+  // Find the WhatsApp JID for this conversation
+  const jid = [...contactMap.entries()].find(
+    ([, v]) => v.conversationId === conversation?.id,
+  )?.[0];
+
+  if (!jid || !content) return res.sendStatus(200);
+
+  try {
+    await client.sendMessage(jid, { conversation: content });
+  } catch (err) {
+    console.error("Failed to send WhatsApp reply:", err);
+  }
+
+  res.sendStatus(200);
+});
+
+async function main() {
+  const { jid } = await client.init();
+  if (!jid) {
+    console.error("Not paired!");
+    process.exit(1);
+  }
+  await client.connect();
+  await client.sendPresence("available");
+  app.listen(3000, () => console.log("Chatwoot bridge on :3000"));
+}
+
+main().catch(console.error);
+```
+
+## Como os Agentes Usam
+
+Uma vez conectado:
+
+1. Usuários do WhatsApp enviam uma mensagem
+2. Ela aparece no Chatwoot como uma nova conversa
+3. Os agentes respondem pelo painel do Chatwoot — como qualquer outro canal
+4. A resposta volta para o WhatsApp pela ponte
+
+Os agentes não precisam saber sobre o whatsmeow-node — eles usam o Chatwoot normalmente.
+
+## Erros Comuns
+
+:::warning Mapa de contatos em memória
+O exemplo armazena o mapeamento JID para contato do Chatwoot em um `Map`. Para produção, persista isso em um banco de dados para sobreviver a reinicializações.
+:::
+
+:::warning A URL do webhook precisa ser acessível
+O Chatwoot precisa alcançar o endpoint do webhook da sua ponte. Se estiver rodando no Docker, use o nome do container ou uma rede compartilhada.
+:::
+
+:::warning Mensagens de grupo
+Este exemplo ignora mensagens de grupo (`info.isGroup`). Se você precisa de suporte a grupos, precisará mapear os JIDs de grupo para conversas do Chatwoot de forma diferente.
+:::
+
+<RelatedGuides slugs={["integrate-whaticket", "integrate-n8n", "send-notifications", "build-a-bot"]} />

--- a/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/integrate-chatwoot.md
+++ b/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/integrate-chatwoot.md
@@ -16,14 +16,14 @@ import {RelatedGuides} from '@site/src/components/RelatedGuides';
     {JSON.stringify({
       "@context": "https://schema.org",
       "@type": "HowTo",
-      "name": "How to Use whatsmeow-node with Chatwoot",
-      "description": "Connect whatsmeow-node to Chatwoot as a WhatsApp channel — receive and reply to WhatsApp messages from the Chatwoot agent dashboard without the official Cloud API.",
+      "name": "Como Usar o whatsmeow-node com Chatwoot",
+      "description": "Conecte o whatsmeow-node ao Chatwoot como canal WhatsApp — receba e responda mensagens do WhatsApp pelo painel de agentes do Chatwoot sem a Cloud API oficial.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/integrate-chatwoot.png",
       "step": [
-        {"@type": "HowToStep", "name": "Create a Chatwoot API Channel", "text": "Set up an API channel in Chatwoot to receive messages via webhook and send via API."},
-        {"@type": "HowToStep", "name": "Build the whatsmeow-node Bridge", "text": "Create a service that forwards WhatsApp messages to Chatwoot and Chatwoot replies to WhatsApp."},
-        {"@type": "HowToStep", "name": "Forward Messages to Chatwoot", "text": "POST incoming WhatsApp messages to Chatwoot's API as incoming messages on the channel."},
-        {"@type": "HowToStep", "name": "Handle Chatwoot Outgoing Webhooks", "text": "Listen for Chatwoot's message_created webhook and send agent replies via whatsmeow-node."}
+        {"@type": "HowToStep", "name": "Criar um Canal API no Chatwoot", "text": "Configure um canal API no Chatwoot para receber mensagens via webhook e enviar via API."},
+        {"@type": "HowToStep", "name": "Construir a Ponte whatsmeow-node", "text": "Crie um serviço que encaminha mensagens do WhatsApp para o Chatwoot e respostas do Chatwoot para o WhatsApp."},
+        {"@type": "HowToStep", "name": "Encaminhar Mensagens para o Chatwoot", "text": "Faça POST das mensagens recebidas do WhatsApp para a API do Chatwoot como mensagens de entrada no canal."},
+        {"@type": "HowToStep", "name": "Tratar Webhooks de Saída do Chatwoot", "text": "Escute o webhook message_created do Chatwoot e envie as respostas dos agentes via whatsmeow-node."}
       ]
     })}
   </script>
@@ -31,8 +31,8 @@ import {RelatedGuides} from '@site/src/components/RelatedGuides';
     {JSON.stringify({
       "@context": "https://schema.org",
       "@type": "Article",
-      "headline": "How to Use whatsmeow-node with Chatwoot",
-      "description": "Connect whatsmeow-node to Chatwoot as a WhatsApp channel — receive and reply to WhatsApp messages from the Chatwoot agent dashboard without the official Cloud API.",
+      "headline": "Como Usar o whatsmeow-node com Chatwoot",
+      "description": "Conecte o whatsmeow-node ao Chatwoot como canal WhatsApp — receba e responda mensagens do WhatsApp pelo painel de agentes do Chatwoot sem a Cloud API oficial.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/integrate-chatwoot.png",
       "author": {"@type": "Organization", "name": "whatsmeow-node", "url": "https://nicastelo.github.io/whatsmeow-node/"},
       "publisher": {"@type": "Organization", "name": "whatsmeow-node", "logo": {"@type": "ImageObject", "url": "https://nicastelo.github.io/whatsmeow-node/img/image.png"}}

--- a/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/integrate-n8n.md
+++ b/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/integrate-n8n.md
@@ -1,0 +1,252 @@
+---
+title: "Como Usar o whatsmeow-node com n8n"
+sidebar_label: Integração com n8n
+sidebar_position: 22
+description: "Conecte o whatsmeow-node ao n8n para automação de fluxos com WhatsApp — envie mensagens, receba webhooks e construa fluxos automatizados sem a Cloud API oficial."
+keywords: [whatsmeow-node n8n, n8n bot whatsapp, n8n integração whatsapp, n8n whatsapp sem cloud api, n8n whatsapp grátis, automação whatsapp n8n]
+---
+
+import Head from '@docusaurus/Head';
+import {RelatedGuides} from '@site/src/components/RelatedGuides';
+
+<Head>
+  <meta property="og:image" content="https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/integrate-n8n.png" />
+  <meta name="twitter:image" content="https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/integrate-n8n.png" />
+  <script type="application/ld+json">
+    {JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "HowTo",
+      "name": "How to Use whatsmeow-node with n8n",
+      "description": "Connect whatsmeow-node to n8n for WhatsApp workflow automation — send messages, receive webhooks, and build automated flows without the official Cloud API.",
+      "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/integrate-n8n.png",
+      "step": [
+        {"@type": "HowToStep", "name": "Create a whatsmeow-node REST API", "text": "Wrap whatsmeow-node in an Express server with send and webhook endpoints."},
+        {"@type": "HowToStep", "name": "Forward Messages to n8n", "text": "POST incoming WhatsApp messages to an n8n webhook trigger URL."},
+        {"@type": "HowToStep", "name": "Send Messages from n8n", "text": "Use n8n's HTTP Request node to call the whatsmeow-node REST API."},
+        {"@type": "HowToStep", "name": "Build Automated Flows", "text": "Create n8n workflows that process messages, query databases, call APIs, and reply."}
+      ]
+    })}
+  </script>
+  <script type="application/ld+json">
+    {JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "Article",
+      "headline": "How to Use whatsmeow-node with n8n",
+      "description": "Connect whatsmeow-node to n8n for WhatsApp workflow automation — send messages, receive webhooks, and build automated flows without the official Cloud API.",
+      "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/integrate-n8n.png",
+      "author": {"@type": "Organization", "name": "whatsmeow-node", "url": "https://nicastelo.github.io/whatsmeow-node/"},
+      "publisher": {"@type": "Organization", "name": "whatsmeow-node", "logo": {"@type": "ImageObject", "url": "https://nicastelo.github.io/whatsmeow-node/img/image.png"}}
+    })}
+  </script>
+</Head>
+
+![Como Usar o whatsmeow-node com n8n](/img/guides/pt-BR/integrate-n8n.png)
+![Como Usar o whatsmeow-node com n8n](/img/guides/pt-BR/integrate-n8n-light.png)
+
+# Como Usar o whatsmeow-node com n8n
+
+O [n8n](https://n8n.io) é uma plataforma de automação de workflows self-hosted — como o Zapier, mas open source. Seu nó WhatsApp nativo requer a Cloud API oficial (verificação Meta Business, cobrança por mensagem). Com o whatsmeow-node, você pode conectar o n8n ao WhatsApp de graça usando uma ponte REST simples.
+
+## Como Funciona
+
+```
+n8n Workflow
+  ↕ HTTP requests / webhooks
+whatsmeow-node REST API (Express)
+  ↕
+WhatsApp
+```
+
+1. **Recebendo**: whatsmeow-node recebe uma mensagem do WhatsApp e faz POST para um webhook do n8n
+2. **Enviando**: um workflow do n8n faz uma requisição HTTP para a REST API do whatsmeow-node, que envia a mensagem
+
+## Pré-requisitos
+
+- Uma sessão pareada do whatsmeow-node ([Como Parear](pair-whatsapp))
+- n8n rodando (self-hosted ou cloud) — `npx n8n` para começar rápido
+- Express: `npm install express`
+
+## Passo 1: Criar a REST API do whatsmeow-node
+
+Este servidor faz duas coisas: envia mensagens via REST e encaminha mensagens recebidas para o n8n.
+
+```typescript
+import { createClient } from "@whatsmeow-node/whatsmeow-node";
+import express from "express";
+
+const client = createClient({ store: "session.db" });
+const app = express();
+app.use(express.json());
+
+// n8n webhook URL — you'll set this up in Step 3
+const N8N_WEBHOOK_URL = process.env.N8N_WEBHOOK_URL ?? "http://localhost:5678/webhook/whatsapp";
+
+// --- Sending endpoint (n8n calls this) ---
+app.post("/api/send", async (req, res) => {
+  const { phone, message, groupJid } = req.body;
+  const jid = groupJid ?? `${phone}@s.whatsapp.net`;
+
+  try {
+    const resp = await client.sendMessage(jid, { conversation: message });
+    res.json({ sent: true, id: resp.id });
+  } catch (err) {
+    res.status(500).json({ error: "Failed to send" });
+  }
+});
+
+// --- Forward incoming messages to n8n ---
+client.on("message", async ({ info, message }) => {
+  if (info.isFromMe) return;
+
+  const text =
+    (message.conversation as string) ??
+    (message.extendedTextMessage as { text?: string } | undefined)?.text;
+
+  // POST to n8n webhook
+  try {
+    await fetch(N8N_WEBHOOK_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        from: info.sender,
+        chat: info.chat,
+        pushName: info.pushName,
+        messageId: info.id,
+        text: text ?? null,
+        isGroup: info.isGroup,
+        timestamp: info.timestamp,
+        hasMedia: !!(
+          message.imageMessage ??
+          message.videoMessage ??
+          message.audioMessage ??
+          message.documentMessage
+        ),
+      }),
+    });
+  } catch (err) {
+    console.error("Failed to forward to n8n:", err);
+  }
+});
+
+async function main() {
+  const { jid } = await client.init();
+  if (!jid) {
+    console.error("Not paired!");
+    process.exit(1);
+  }
+  await client.connect();
+  app.listen(3000, () => console.log("WhatsApp API on :3000"));
+}
+
+main().catch(console.error);
+```
+
+## Passo 2: Configurar o Webhook Trigger no n8n
+
+No n8n, crie um novo workflow:
+
+1. Adicione um nó **Webhook** como trigger
+2. Defina o método como `POST`
+3. Defina o path como `whatsapp` (gerando a URL `http://localhost:5678/webhook/whatsapp`)
+4. Configure a URL do webhook como `N8N_WEBHOOK_URL` no ambiente da sua REST API
+
+Agora cada mensagem recebida pelo WhatsApp aciona esse workflow do n8n.
+
+## Passo 3: Enviar Mensagens a partir do n8n
+
+Adicione um nó **HTTP Request** ao seu workflow do n8n:
+
+- **Method**: POST
+- **URL**: `http://localhost:3000/api/send`
+- **Body (JSON)**:
+```json
+{
+  "phone": "{{ $json.from.replace('@s.whatsapp.net', '') }}",
+  "message": "Thanks for your message! We'll get back to you soon."
+}
+```
+
+## Exemplo: Workflow de Auto-Resposta
+
+Um workflow completo do n8n que responde automaticamente a mensagens:
+
+```
+[Webhook Trigger] → [IF: text contains "price"] → [HTTP Request: send reply]
+                  → [IF: text contains "help"]  → [HTTP Request: send help menu]
+                  → [Default]                    → [HTTP Request: send acknowledgment]
+```
+
+## Exemplo: Integração com CRM
+
+Encaminhe mensagens do WhatsApp para um CRM e responda com o número do ticket:
+
+```
+[Webhook Trigger] → [HTTP Request: create CRM ticket]
+                  → [Set: extract ticket ID]
+                  → [HTTP Request: send "Your ticket #{{ ticketId }} has been created"]
+```
+
+## Exemplo: Auto-Resposta com IA
+
+Combine com OpenAI no n8n:
+
+```
+[Webhook Trigger] → [OpenAI Chat: generate reply]
+                  → [HTTP Request: send AI reply via whatsmeow-node]
+```
+
+## Adicionando Mais Endpoints
+
+Expanda a REST API para workflows do n8n que precisam de mais funcionalidades:
+
+```typescript
+// Send media
+app.post("/api/send-media", async (req, res) => {
+  const { phone, filePath, mediaType, caption } = req.body;
+  const jid = `${phone}@s.whatsapp.net`;
+  const media = await client.uploadMedia(filePath, mediaType);
+  await client.sendRawMessage(jid, {
+    [`${mediaType}Message`]: {
+      URL: media.URL,
+      directPath: media.directPath,
+      mediaKey: media.mediaKey,
+      fileEncSHA256: media.fileEncSHA256,
+      fileSHA256: media.fileSHA256,
+      fileLength: String(media.fileLength),
+      mimetype: `${mediaType}/*`,
+      ...(caption && { caption }),
+    },
+  });
+  res.json({ sent: true });
+});
+
+// Send to group
+app.post("/api/send-group", async (req, res) => {
+  const { groupJid, message } = req.body;
+  const resp = await client.sendMessage(groupJid, { conversation: message });
+  res.json({ sent: true, id: resp.id });
+});
+
+// Mark as read
+app.post("/api/read", async (req, res) => {
+  const { messageId, chat, sender } = req.body;
+  await client.markRead([messageId], chat, sender);
+  res.json({ ok: true });
+});
+```
+
+## Erros Comuns
+
+:::warning Mantenha os dois serviços rodando
+A REST API do whatsmeow-node e o n8n precisam estar rodando ao mesmo tempo. Use PM2 ou Docker Compose para gerenciá-los juntos.
+:::
+
+:::warning A URL do webhook precisa ser acessível
+A URL do webhook do n8n precisa ser acessível a partir do servidor do whatsmeow-node. No Docker, use o nome do container ou alias de rede, não `localhost`.
+:::
+
+:::warning Rate limiting
+Workflows do n8n podem executar muito rápido. Se o seu workflow envia múltiplas mensagens, adicione um nó **Wait** (1-3 segundos) entre os envios para evitar rate limiting do WhatsApp.
+:::
+
+<RelatedGuides slugs={["send-notifications", "integrate-whaticket", "build-a-bot", "connect-to-chatgpt"]} />

--- a/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/integrate-n8n.md
+++ b/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/integrate-n8n.md
@@ -16,14 +16,14 @@ import {RelatedGuides} from '@site/src/components/RelatedGuides';
     {JSON.stringify({
       "@context": "https://schema.org",
       "@type": "HowTo",
-      "name": "How to Use whatsmeow-node with n8n",
-      "description": "Connect whatsmeow-node to n8n for WhatsApp workflow automation — send messages, receive webhooks, and build automated flows without the official Cloud API.",
+      "name": "Como Usar o whatsmeow-node com n8n",
+      "description": "Conecte o whatsmeow-node ao n8n para automação de fluxos com WhatsApp — envie mensagens, receba webhooks e construa fluxos automatizados sem a Cloud API oficial.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/integrate-n8n.png",
       "step": [
-        {"@type": "HowToStep", "name": "Create a whatsmeow-node REST API", "text": "Wrap whatsmeow-node in an Express server with send and webhook endpoints."},
-        {"@type": "HowToStep", "name": "Forward Messages to n8n", "text": "POST incoming WhatsApp messages to an n8n webhook trigger URL."},
-        {"@type": "HowToStep", "name": "Send Messages from n8n", "text": "Use n8n's HTTP Request node to call the whatsmeow-node REST API."},
-        {"@type": "HowToStep", "name": "Build Automated Flows", "text": "Create n8n workflows that process messages, query databases, call APIs, and reply."}
+        {"@type": "HowToStep", "name": "Criar a REST API do whatsmeow-node", "text": "Encapsule o whatsmeow-node em um servidor Express com endpoints de envio e webhook."},
+        {"@type": "HowToStep", "name": "Encaminhar Mensagens para o n8n", "text": "Faça POST das mensagens recebidas do WhatsApp para uma URL de webhook trigger do n8n."},
+        {"@type": "HowToStep", "name": "Enviar Mensagens a partir do n8n", "text": "Use o nó HTTP Request do n8n para chamar a REST API do whatsmeow-node."},
+        {"@type": "HowToStep", "name": "Construir Fluxos Automatizados", "text": "Crie workflows no n8n que processam mensagens, consultam bancos de dados, chamam APIs e respondem."}
       ]
     })}
   </script>
@@ -31,8 +31,8 @@ import {RelatedGuides} from '@site/src/components/RelatedGuides';
     {JSON.stringify({
       "@context": "https://schema.org",
       "@type": "Article",
-      "headline": "How to Use whatsmeow-node with n8n",
-      "description": "Connect whatsmeow-node to n8n for WhatsApp workflow automation — send messages, receive webhooks, and build automated flows without the official Cloud API.",
+      "headline": "Como Usar o whatsmeow-node com n8n",
+      "description": "Conecte o whatsmeow-node ao n8n para automação de fluxos com WhatsApp — envie mensagens, receba webhooks e construa fluxos automatizados sem a Cloud API oficial.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/integrate-n8n.png",
       "author": {"@type": "Organization", "name": "whatsmeow-node", "url": "https://nicastelo.github.io/whatsmeow-node/"},
       "publisher": {"@type": "Organization", "name": "whatsmeow-node", "logo": {"@type": "ImageObject", "url": "https://nicastelo.github.io/whatsmeow-node/img/image.png"}}

--- a/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/integrate-typebot.md
+++ b/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/integrate-typebot.md
@@ -1,0 +1,269 @@
+---
+title: "Como Usar o whatsmeow-node com Typebot"
+sidebar_label: Integração com Typebot
+sidebar_position: 24
+description: "Conecte o whatsmeow-node ao Typebot para fluxos de chatbot no WhatsApp — substitua a Evolution API por um backend WhatsApp mais leve e estável."
+keywords: [typebot whatsapp, typebot whatsmeow, typebot alternativa evolution api, typebot bot whatsapp, typebot integração whatsapp, typebot whatsapp nodejs]
+---
+
+import Head from '@docusaurus/Head';
+import {RelatedGuides} from '@site/src/components/RelatedGuides';
+
+<Head>
+  <meta property="og:image" content="https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/integrate-typebot.png" />
+  <meta name="twitter:image" content="https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/integrate-typebot.png" />
+  <script type="application/ld+json">
+    {JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "HowTo",
+      "name": "How to Use whatsmeow-node with Typebot",
+      "description": "Connect whatsmeow-node to Typebot for WhatsApp chatbot flows — replace Evolution API with a lighter, more stable WhatsApp backend.",
+      "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/integrate-typebot.png",
+      "step": [
+        {"@type": "HowToStep", "name": "Build a whatsmeow-node REST API", "text": "Create an Express server that bridges WhatsApp messages to Typebot via HTTP."},
+        {"@type": "HowToStep", "name": "Start a Typebot Flow", "text": "POST the first message to Typebot's API to start a conversation flow."},
+        {"@type": "HowToStep", "name": "Continue the Conversation", "text": "Send user replies to Typebot's continueChat endpoint and relay bot responses to WhatsApp."},
+        {"@type": "HowToStep", "name": "Handle Rich Messages", "text": "Parse Typebot's response blocks (text, image, input) and send appropriate WhatsApp messages."}
+      ]
+    })}
+  </script>
+  <script type="application/ld+json">
+    {JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "Article",
+      "headline": "How to Use whatsmeow-node with Typebot",
+      "description": "Connect whatsmeow-node to Typebot for WhatsApp chatbot flows — replace Evolution API with a lighter, more stable WhatsApp backend.",
+      "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/integrate-typebot.png",
+      "author": {"@type": "Organization", "name": "whatsmeow-node", "url": "https://nicastelo.github.io/whatsmeow-node/"},
+      "publisher": {"@type": "Organization", "name": "whatsmeow-node", "logo": {"@type": "ImageObject", "url": "https://nicastelo.github.io/whatsmeow-node/img/image.png"}}
+    })}
+  </script>
+</Head>
+
+![Como Usar o whatsmeow-node com Typebot](/img/guides/pt-BR/integrate-typebot.png)
+![Como Usar o whatsmeow-node com Typebot](/img/guides/pt-BR/integrate-typebot-light.png)
+
+# Como Usar o whatsmeow-node com Typebot
+
+O [Typebot](https://typebot.io) é um construtor de chatbots open-source com editor visual de fluxos. Normalmente é conectado ao WhatsApp através da [Evolution API](https://github.com/EvolutionAPI/evolution-api) (que usa Baileys). Você pode substituir toda essa camada pelo whatsmeow-node para uma conexão mais leve e estável.
+
+## Como Funciona
+
+```
+WhatsApp User
+  ↕
+whatsmeow-node Bridge (Express)
+  ↕ Typebot API
+Typebot Flow Engine
+```
+
+Em vez de `WhatsApp, Evolution API (Baileys), Typebot`, você usa `WhatsApp, whatsmeow-node, Typebot` diretamente. Menos peças móveis, menos memória, mais estabilidade.
+
+## Pré-requisitos
+
+- Uma sessão pareada do whatsmeow-node ([Como Parear](pair-whatsapp))
+- Uma instância do Typebot (self-hosted ou cloud) com um fluxo publicado
+- Express: `npm install express`
+
+## Passo 1: Obter o ID do Typebot
+
+1. Abra seu fluxo do Typebot no editor
+2. Clique em **Share** e anote o ID do typebot na URL ou nas configurações de embed
+3. A URL base da API do Typebot é `https://typebot.io` (cloud) ou a URL do seu self-hosted
+
+## Passo 2: Construir a Ponte
+
+A ponte gerencia as conversas — ela inicia uma sessão do Typebot por usuário do WhatsApp e repassa as mensagens nos dois sentidos:
+
+```typescript
+import { createClient } from "@whatsmeow-node/whatsmeow-node";
+
+const client = createClient({ store: "session.db" });
+
+const TYPEBOT_URL = process.env.TYPEBOT_URL ?? "https://typebot.io";
+const TYPEBOT_ID = process.env.TYPEBOT_ID!;
+
+// Track active Typebot sessions per WhatsApp user
+const sessions = new Map<string, string>(); // JID → sessionId
+
+// --- Start or continue a Typebot conversation ---
+async function handleMessage(jid: string, text: string): Promise<string[]> {
+  const sessionId = sessions.get(jid);
+
+  let response;
+
+  if (!sessionId) {
+    // Start a new Typebot session
+    response = await fetch(`${TYPEBOT_URL}/api/v1/typebots/${TYPEBOT_ID}/startChat`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ message: { type: "text", text } }),
+    }).then((r) => r.json());
+
+    if (response.sessionId) {
+      sessions.set(jid, response.sessionId);
+    }
+  } else {
+    // Continue existing session
+    response = await fetch(`${TYPEBOT_URL}/api/v1/sessions/${sessionId}/continueChat`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ message: { type: "text", text } }),
+    }).then((r) => r.json());
+  }
+
+  // Extract text messages from Typebot response
+  return extractMessages(response);
+}
+
+// --- Parse Typebot response blocks into text messages ---
+function extractMessages(response: Record<string, unknown>): string[] {
+  const messages: string[] = [];
+  const msgs = (response.messages as Array<{ type: string; content?: { richText?: Array<{ children: Array<{ text?: string }> }> } }>) ?? [];
+
+  for (const msg of msgs) {
+    if (msg.type === "text" && msg.content?.richText) {
+      const text = msg.content.richText
+        .map((block) => block.children.map((c) => c.text ?? "").join(""))
+        .join("\n");
+      if (text.trim()) messages.push(text);
+    }
+  }
+
+  return messages;
+}
+
+// --- Listen for WhatsApp messages ---
+client.on("message", async ({ info, message }) => {
+  if (info.isFromMe || info.isGroup) return;
+
+  const text =
+    (message.conversation as string) ??
+    (message.extendedTextMessage as { text?: string } | undefined)?.text;
+  if (!text) return;
+
+  await client.sendChatPresence(info.chat, "composing");
+
+  try {
+    const replies = await handleMessage(info.sender, text);
+
+    for (const reply of replies) {
+      await client.sendMessage(info.chat, { conversation: reply });
+      // Small delay between multiple messages
+      if (replies.length > 1) {
+        await new Promise((r) => setTimeout(r, 1000));
+      }
+    }
+  } catch (err) {
+    console.error("Typebot error:", err);
+    await client.sendMessage(info.chat, {
+      conversation: "Sorry, I'm having trouble right now. Try again in a moment.",
+    });
+  }
+});
+
+async function main() {
+  const { jid } = await client.init();
+  if (!jid) {
+    console.error("Not paired!");
+    process.exit(1);
+  }
+  await client.connect();
+  await client.sendPresence("available");
+  console.log("Typebot bridge is online!");
+
+  process.on("SIGINT", async () => {
+    await client.sendPresence("unavailable");
+    await client.disconnect();
+    client.close();
+    process.exit(0);
+  });
+}
+
+main().catch(console.error);
+```
+
+## Tratando Tipos de Input
+
+Fluxos do Typebot podem solicitar diferentes tipos de input. Trate-os verificando o bloco `input`:
+
+```typescript
+function extractMessages(response: Record<string, unknown>): string[] {
+  const messages: string[] = [];
+  const msgs = (response.messages as Array<Record<string, unknown>>) ?? [];
+
+  for (const msg of msgs) {
+    if (msg.type === "text" && (msg.content as Record<string, unknown>)?.richText) {
+      const richText = (msg.content as Record<string, unknown>).richText as Array<{ children: Array<{ text?: string }> }>;
+      const text = richText
+        .map((block) => block.children.map((c) => c.text ?? "").join(""))
+        .join("\n");
+      if (text.trim()) messages.push(text);
+    }
+  }
+
+  // If the flow expects input, prompt the user
+  const input = response.input as Record<string, unknown> | undefined;
+  if (input) {
+    const inputType = input.type as string;
+    if (inputType === "choice input") {
+      const items = (input.items as Array<{ content: string }>) ?? [];
+      const options = items.map((item, i) => `${i + 1}. ${item.content}`).join("\n");
+      messages.push(options);
+    }
+  }
+
+  return messages;
+}
+```
+
+## Resetando Conversas
+
+Adicione um comando `!reset` para reiniciar o fluxo do Typebot:
+
+```typescript
+client.on("message", async ({ info, message }) => {
+  if (info.isFromMe || info.isGroup) return;
+
+  const text = /* ... extract text ... */;
+  if (!text) return;
+
+  if (text.toLowerCase() === "!reset") {
+    sessions.delete(info.sender);
+    await client.sendMessage(info.chat, {
+      conversation: "Conversation reset! Send a message to start over.",
+    });
+    return;
+  }
+
+  // ... handle message as before
+});
+```
+
+## Evolution API vs whatsmeow-node
+
+Se você está usando a Evolution API com Typebot atualmente, veja o que muda:
+
+| | Evolution API | ponte whatsmeow-node |
+|---|---|---|
+| **Backend WhatsApp** | Baileys | whatsmeow (Go) |
+| **Memória** | ~50-100 MB | ~10-20 MB |
+| **Arquitetura** | Serviço separado | Embutido na ponte |
+| **Setup** | Docker + config | `npm install` + 50 linhas |
+| **Estabilidade** | Atualizações de fork do Baileys | Upstream estável |
+
+## Erros Comuns
+
+:::warning Expiração de sessão
+Sessões do Typebot podem expirar. Se o `continueChat` retornar um erro, delete a sessão do map e inicie uma nova.
+:::
+
+:::warning Rate limiting
+Fluxos do Typebot podem enviar múltiplas mensagens em sequência. Adicione um pequeno delay (1 segundo) entre as mensagens para evitar rate limiting do WhatsApp.
+:::
+
+:::warning Conteúdo rico
+O Typebot suporta imagens, vídeos e botões nos fluxos. A ponte básica acima só trata texto. Expanda `extractMessages()` para tratar blocos de mídia e enviá-los via `uploadMedia()` + `sendRawMessage()`.
+:::
+
+<RelatedGuides slugs={["integrate-whaticket", "integrate-n8n", "connect-to-chatgpt", "build-a-bot"]} />

--- a/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/integrate-typebot.md
+++ b/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/integrate-typebot.md
@@ -16,14 +16,14 @@ import {RelatedGuides} from '@site/src/components/RelatedGuides';
     {JSON.stringify({
       "@context": "https://schema.org",
       "@type": "HowTo",
-      "name": "How to Use whatsmeow-node with Typebot",
-      "description": "Connect whatsmeow-node to Typebot for WhatsApp chatbot flows — replace Evolution API with a lighter, more stable WhatsApp backend.",
+      "name": "Como Usar o whatsmeow-node com Typebot",
+      "description": "Conecte o whatsmeow-node ao Typebot para fluxos de chatbot no WhatsApp — substitua a Evolution API por um backend WhatsApp mais leve e estável.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/integrate-typebot.png",
       "step": [
-        {"@type": "HowToStep", "name": "Build a whatsmeow-node REST API", "text": "Create an Express server that bridges WhatsApp messages to Typebot via HTTP."},
-        {"@type": "HowToStep", "name": "Start a Typebot Flow", "text": "POST the first message to Typebot's API to start a conversation flow."},
-        {"@type": "HowToStep", "name": "Continue the Conversation", "text": "Send user replies to Typebot's continueChat endpoint and relay bot responses to WhatsApp."},
-        {"@type": "HowToStep", "name": "Handle Rich Messages", "text": "Parse Typebot's response blocks (text, image, input) and send appropriate WhatsApp messages."}
+        {"@type": "HowToStep", "name": "Construir a REST API do whatsmeow-node", "text": "Crie um servidor Express que conecta mensagens do WhatsApp ao Typebot via HTTP."},
+        {"@type": "HowToStep", "name": "Iniciar um Fluxo do Typebot", "text": "Faça POST da primeira mensagem para a API do Typebot para iniciar um fluxo de conversa."},
+        {"@type": "HowToStep", "name": "Continuar a Conversa", "text": "Envie as respostas do usuário para o endpoint continueChat do Typebot e repasse as respostas do bot para o WhatsApp."},
+        {"@type": "HowToStep", "name": "Tratar Mensagens Ricas", "text": "Parse os blocos de resposta do Typebot (texto, imagem, input) e envie as mensagens WhatsApp apropriadas."}
       ]
     })}
   </script>
@@ -31,8 +31,8 @@ import {RelatedGuides} from '@site/src/components/RelatedGuides';
     {JSON.stringify({
       "@context": "https://schema.org",
       "@type": "Article",
-      "headline": "How to Use whatsmeow-node with Typebot",
-      "description": "Connect whatsmeow-node to Typebot for WhatsApp chatbot flows — replace Evolution API with a lighter, more stable WhatsApp backend.",
+      "headline": "Como Usar o whatsmeow-node com Typebot",
+      "description": "Conecte o whatsmeow-node ao Typebot para fluxos de chatbot no WhatsApp — substitua a Evolution API por um backend WhatsApp mais leve e estável.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/integrate-typebot.png",
       "author": {"@type": "Organization", "name": "whatsmeow-node", "url": "https://nicastelo.github.io/whatsmeow-node/"},
       "publisher": {"@type": "Organization", "name": "whatsmeow-node", "logo": {"@type": "ImageObject", "url": "https://nicastelo.github.io/whatsmeow-node/img/image.png"}}

--- a/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/integrate-whaticket.md
+++ b/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/integrate-whaticket.md
@@ -16,15 +16,15 @@ import {RelatedGuides} from '@site/src/components/RelatedGuides';
     {JSON.stringify({
       "@context": "https://schema.org",
       "@type": "HowTo",
-      "name": "How to Use whatsmeow-node with Whaticket",
-      "description": "Replace whatsapp-web.js with whatsmeow-node in Whaticket — drop Puppeteer, cut memory usage, and get a more stable WhatsApp connection for your helpdesk.",
+      "name": "Como Usar o whatsmeow-node com Whaticket",
+      "description": "Substitua o whatsapp-web.js pelo whatsmeow-node no Whaticket — elimine o Puppeteer, reduza o uso de memória e tenha uma conexão WhatsApp mais estável para seu helpdesk.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/integrate-whaticket.png",
       "step": [
-        {"@type": "HowToStep", "name": "Install whatsmeow-node", "text": "Add whatsmeow-node to the Whaticket backend and remove whatsapp-web.js and Puppeteer."},
-        {"@type": "HowToStep", "name": "Create the WhatsApp Service", "text": "Build a service module that wraps whatsmeow-node and exposes send/receive methods for Whaticket."},
-        {"@type": "HowToStep", "name": "Handle QR Pairing", "text": "Emit QR codes to the Whaticket frontend via the existing WebSocket connection."},
-        {"@type": "HowToStep", "name": "Route Messages to Tickets", "text": "Listen for incoming messages and create or update tickets in the database."},
-        {"@type": "HowToStep", "name": "Send Replies", "text": "When agents reply in the Whaticket UI, send the message via whatsmeow-node."}
+        {"@type": "HowToStep", "name": "Instalar o whatsmeow-node", "text": "Adicione o whatsmeow-node ao backend do Whaticket e remova whatsapp-web.js e Puppeteer."},
+        {"@type": "HowToStep", "name": "Criar o Serviço WhatsApp", "text": "Construa um módulo de serviço que encapsula o whatsmeow-node e expõe métodos de envio/recebimento para o Whaticket."},
+        {"@type": "HowToStep", "name": "Tratar o Pareamento via QR", "text": "Emita QR codes para o frontend do Whaticket pela conexão WebSocket existente."},
+        {"@type": "HowToStep", "name": "Rotear Mensagens para Tickets", "text": "Escute mensagens recebidas e crie ou atualize tickets no banco de dados."},
+        {"@type": "HowToStep", "name": "Enviar Respostas", "text": "Quando os agentes respondem pela UI do Whaticket, envie a mensagem via whatsmeow-node."}
       ]
     })}
   </script>
@@ -32,8 +32,8 @@ import {RelatedGuides} from '@site/src/components/RelatedGuides';
     {JSON.stringify({
       "@context": "https://schema.org",
       "@type": "Article",
-      "headline": "How to Use whatsmeow-node with Whaticket",
-      "description": "Replace whatsapp-web.js with whatsmeow-node in Whaticket — drop Puppeteer, cut memory usage, and get a more stable WhatsApp connection for your helpdesk.",
+      "headline": "Como Usar o whatsmeow-node com Whaticket",
+      "description": "Substitua o whatsapp-web.js pelo whatsmeow-node no Whaticket — elimine o Puppeteer, reduza o uso de memória e tenha uma conexão WhatsApp mais estável para seu helpdesk.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/integrate-whaticket.png",
       "author": {"@type": "Organization", "name": "whatsmeow-node", "url": "https://nicastelo.github.io/whatsmeow-node/"},
       "publisher": {"@type": "Organization", "name": "whatsmeow-node", "logo": {"@type": "ImageObject", "url": "https://nicastelo.github.io/whatsmeow-node/img/image.png"}}

--- a/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/integrate-whaticket.md
+++ b/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/integrate-whaticket.md
@@ -1,0 +1,353 @@
+---
+title: "Como Usar o whatsmeow-node com Whaticket"
+sidebar_label: Integração com Whaticket
+sidebar_position: 21
+description: "Substitua o whatsapp-web.js pelo whatsmeow-node no Whaticket — elimine o Puppeteer, reduza o uso de memória e tenha uma conexão WhatsApp mais estável para seu helpdesk."
+keywords: [whaticket whatsmeow, whaticket sem baileys, whaticket alternativa whatsapp-web.js, whaticket whatsmeow-node, whaticket estável, whaticket sem puppeteer]
+---
+
+import Head from '@docusaurus/Head';
+import {RelatedGuides} from '@site/src/components/RelatedGuides';
+
+<Head>
+  <meta property="og:image" content="https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/integrate-whaticket.png" />
+  <meta name="twitter:image" content="https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/integrate-whaticket.png" />
+  <script type="application/ld+json">
+    {JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "HowTo",
+      "name": "How to Use whatsmeow-node with Whaticket",
+      "description": "Replace whatsapp-web.js with whatsmeow-node in Whaticket — drop Puppeteer, cut memory usage, and get a more stable WhatsApp connection for your helpdesk.",
+      "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/integrate-whaticket.png",
+      "step": [
+        {"@type": "HowToStep", "name": "Install whatsmeow-node", "text": "Add whatsmeow-node to the Whaticket backend and remove whatsapp-web.js and Puppeteer."},
+        {"@type": "HowToStep", "name": "Create the WhatsApp Service", "text": "Build a service module that wraps whatsmeow-node and exposes send/receive methods for Whaticket."},
+        {"@type": "HowToStep", "name": "Handle QR Pairing", "text": "Emit QR codes to the Whaticket frontend via the existing WebSocket connection."},
+        {"@type": "HowToStep", "name": "Route Messages to Tickets", "text": "Listen for incoming messages and create or update tickets in the database."},
+        {"@type": "HowToStep", "name": "Send Replies", "text": "When agents reply in the Whaticket UI, send the message via whatsmeow-node."}
+      ]
+    })}
+  </script>
+  <script type="application/ld+json">
+    {JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "Article",
+      "headline": "How to Use whatsmeow-node with Whaticket",
+      "description": "Replace whatsapp-web.js with whatsmeow-node in Whaticket — drop Puppeteer, cut memory usage, and get a more stable WhatsApp connection for your helpdesk.",
+      "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/integrate-whaticket.png",
+      "author": {"@type": "Organization", "name": "whatsmeow-node", "url": "https://nicastelo.github.io/whatsmeow-node/"},
+      "publisher": {"@type": "Organization", "name": "whatsmeow-node", "logo": {"@type": "ImageObject", "url": "https://nicastelo.github.io/whatsmeow-node/img/image.png"}}
+    })}
+  </script>
+</Head>
+
+![Como Usar o whatsmeow-node com Whaticket](/img/guides/pt-BR/integrate-whaticket.png)
+![Como Usar o whatsmeow-node com Whaticket](/img/guides/pt-BR/integrate-whaticket-light.png)
+
+# Como Usar o whatsmeow-node com Whaticket
+
+O [Whaticket](https://github.com/canove/whaticket-community) é um helpdesk WhatsApp open-source construído com Express + React. Ele usa whatsapp-web.js (baseado em Puppeteer) para conectividade com o WhatsApp, que é pesado (~500 MB de RAM), quebra com atualizações do WhatsApp Web e requer um navegador headless.
+
+O whatsmeow-node é um substituto direto — mesmo padrão orientado a eventos, mesmo runtime Node.js, mas 10-20 MB de RAM em vez de 500 MB, sem navegador e protocolo mais estável.
+
+## Por Que Substituir o whatsapp-web.js no Whaticket?
+
+| | whatsapp-web.js (atual) | whatsmeow-node |
+|---|---|---|
+| **Memória por sessão** | 200-500 MB (Chromium) | ~10-20 MB |
+| **Startup** | 5-15s (iniciar navegador) | Menos de 1 segundo |
+| **Estabilidade** | Quebra com atualizações do WhatsApp Web | Upstream estável (whatsmeow) |
+| **Imagem Docker** | ~1 GB+ (precisa do Chrome) | ~50 MB |
+| **Protocolo** | Automação do client web | Multi-dispositivo nativo |
+
+Para deploys Whaticket multi-sessão, isso significa rodar 10+ conexões WhatsApp em um único VPS de 1 GB em vez de precisar de 4+ GB.
+
+## Visão Geral da Arquitetura
+
+A integração WhatsApp do Whaticket fica no backend Express:
+
+```
+Whaticket Frontend (React)
+  ↕ WebSocket + REST
+Whaticket Backend (Express)
+  ↕ WhatsApp Service
+whatsapp-web.js → Replace with whatsmeow-node
+  ↕
+WhatsApp
+```
+
+A troca acontece na camada do serviço WhatsApp — tudo acima (tickets, contatos, UI) continua igual.
+
+## Passo 1: Instalar o whatsmeow-node
+
+No diretório do backend do Whaticket:
+
+```bash
+# Remove whatsapp-web.js and Puppeteer
+npm uninstall whatsapp-web.js puppeteer
+
+# Install whatsmeow-node
+npm install @whatsmeow-node/whatsmeow-node
+```
+
+## Passo 2: Criar o Serviço WhatsApp
+
+Substitua o serviço whatsapp-web.js por um wrapper do whatsmeow-node:
+
+```typescript
+// src/services/WhatsappService.ts
+import { createClient, WhatsmeowClient } from "@whatsmeow-node/whatsmeow-node";
+import { EventEmitter } from "events";
+
+export class WhatsappService extends EventEmitter {
+  private client: WhatsmeowClient;
+  private jid: string | null = null;
+
+  constructor(sessionId: string, storePath: string) {
+    super();
+    this.client = createClient({ store: `${storePath}/${sessionId}.db` });
+    this.setupListeners();
+  }
+
+  private setupListeners() {
+    this.client.on("qr", ({ code }) => {
+      this.emit("qr", code);
+    });
+
+    this.client.on("connected", ({ jid }) => {
+      this.jid = jid;
+      this.emit("ready", jid);
+    });
+
+    this.client.on("message", ({ info, message }) => {
+      if (info.isFromMe) return;
+      this.emit("message", { info, message });
+    });
+
+    this.client.on("disconnected", () => {
+      this.emit("disconnected");
+    });
+
+    this.client.on("logged_out", ({ reason }) => {
+      this.emit("logged_out", reason);
+    });
+  }
+
+  async start() {
+    const { jid } = await this.client.init();
+    if (jid) {
+      this.jid = jid;
+      await this.client.connect();
+      return { paired: true, jid };
+    }
+    // Not paired — start QR flow
+    await this.client.getQRChannel();
+    await this.client.connect();
+    return { paired: false };
+  }
+
+  async sendText(to: string, text: string) {
+    return this.client.sendMessage(to, { conversation: text });
+  }
+
+  async sendMedia(to: string, filePath: string, mediaType: "image" | "video" | "audio" | "document", caption?: string) {
+    const media = await this.client.uploadMedia(filePath, mediaType);
+    const typeKey = `${mediaType}Message`;
+    return this.client.sendRawMessage(to, {
+      [typeKey]: {
+        URL: media.URL,
+        directPath: media.directPath,
+        mediaKey: media.mediaKey,
+        fileEncSHA256: media.fileEncSHA256,
+        fileSHA256: media.fileSHA256,
+        fileLength: String(media.fileLength),
+        mimetype: this.getMimeType(filePath, mediaType),
+        ...(caption && { caption }),
+      },
+    });
+  }
+
+  async markRead(messageId: string, chat: string, sender?: string) {
+    await this.client.markRead([messageId], chat, sender);
+  }
+
+  async disconnect() {
+    await this.client.sendPresence("unavailable");
+    await this.client.disconnect();
+    this.client.close();
+  }
+
+  getJid() {
+    return this.jid;
+  }
+
+  private getMimeType(filePath: string, mediaType: string): string {
+    const ext = filePath.split(".").pop()?.toLowerCase();
+    const mimes: Record<string, string> = {
+      jpg: "image/jpeg", jpeg: "image/jpeg", png: "image/png", gif: "image/gif",
+      mp4: "video/mp4", mp3: "audio/mpeg", ogg: "audio/ogg",
+      pdf: "application/pdf", doc: "application/msword",
+    };
+    return mimes[ext ?? ""] ?? `${mediaType}/*`;
+  }
+}
+```
+
+## Passo 3: Tratar o Pareamento via QR por WebSocket
+
+O Whaticket exibe QR codes na UI administrativa. Encaminhe-os pelo WebSocket existente:
+
+```typescript
+// In your session initialization handler
+import { WhatsappService } from "./services/WhatsappService";
+
+const sessions = new Map<string, WhatsappService>();
+
+function initSession(sessionId: string, io: SocketIO.Server) {
+  const service = new WhatsappService(sessionId, "./sessions");
+
+  service.on("qr", (code) => {
+    // Send QR to the admin UI via WebSocket
+    io.to(sessionId).emit("whatsapp:qr", { code });
+  });
+
+  service.on("ready", (jid) => {
+    io.to(sessionId).emit("whatsapp:ready", { jid });
+    // Update session status in database
+    updateSessionStatus(sessionId, "connected", jid);
+  });
+
+  service.on("message", async ({ info, message }) => {
+    // Route to ticket system
+    await handleIncomingMessage(sessionId, info, message);
+  });
+
+  service.on("disconnected", () => {
+    io.to(sessionId).emit("whatsapp:disconnected");
+    updateSessionStatus(sessionId, "disconnected");
+  });
+
+  service.start();
+  sessions.set(sessionId, service);
+}
+```
+
+## Passo 4: Rotear Mensagens para Tickets
+
+Converta mensagens recebidas do WhatsApp em tickets do Whaticket:
+
+```typescript
+async function handleIncomingMessage(
+  sessionId: string,
+  info: { chat: string; sender: string; pushName: string; id: string; isGroup: boolean },
+  message: Record<string, unknown>,
+) {
+  const contactJid = info.isGroup ? info.sender : info.chat;
+
+  // Find or create contact
+  const contact = await findOrCreateContact(contactJid, info.pushName);
+
+  // Find open ticket or create new one
+  const ticket = await findOrCreateTicket(contact.id, sessionId);
+
+  // Extract message text
+  const text =
+    (message.conversation as string) ??
+    (message.extendedTextMessage as { text?: string } | undefined)?.text ??
+    "[media]";
+
+  // Save message to ticket
+  await createMessage({
+    ticketId: ticket.id,
+    contactId: contact.id,
+    body: text,
+    fromMe: false,
+    messageId: info.id,
+  });
+
+  // Notify agents via WebSocket
+  io.to(`ticket:${ticket.id}`).emit("ticket:message", {
+    ticketId: ticket.id,
+    message: text,
+    contact: contact.name,
+  });
+}
+```
+
+## Passo 5: Enviar Respostas
+
+Quando um agente responde pela UI do Whaticket:
+
+```typescript
+// In your message sending endpoint
+app.post("/api/messages/:ticketId", async (req, res) => {
+  const { ticketId } = req.params;
+  const { body, mediaPath, mediaType } = req.body;
+
+  const ticket = await getTicket(ticketId);
+  const session = sessions.get(ticket.sessionId);
+  if (!session) return res.status(400).json({ error: "Session not connected" });
+
+  let response;
+  if (mediaPath) {
+    response = await session.sendMedia(ticket.contactJid, mediaPath, mediaType, body);
+  } else {
+    response = await session.sendText(ticket.contactJid, body);
+  }
+
+  // Save outgoing message
+  await createMessage({
+    ticketId: ticket.id,
+    body,
+    fromMe: true,
+    messageId: response.id,
+  });
+
+  res.json({ sent: true, id: response.id });
+});
+```
+
+## Gerenciamento Multi-Sessão
+
+O Whaticket suporta múltiplos números de WhatsApp. O whatsmeow-node trata isso com instâncias de client separadas:
+
+```typescript
+// Each session gets its own client + database
+const session1 = new WhatsappService("support", "./sessions");   // sessions/support.db
+const session2 = new WhatsappService("sales", "./sessions");     // sessions/sales.db
+const session3 = new WhatsappService("marketing", "./sessions"); // sessions/marketing.db
+
+// Total memory: ~30-60 MB for 3 sessions
+// With whatsapp-web.js: ~1.5 GB for 3 sessions
+```
+
+## Limpeza do Docker
+
+Remova o Chromium do seu Dockerfile:
+
+```dockerfile
+# Before (whatsapp-web.js)
+FROM node:20
+RUN apt-get update && apt-get install -y chromium
+# Image size: ~1.2 GB
+
+# After (whatsmeow-node)
+FROM node:20-slim
+# Image size: ~200 MB
+```
+
+## Erros Comuns
+
+:::warning Migração de sessão
+As sessões do whatsapp-web.js não podem ser migradas. Cada número do WhatsApp precisa parear novamente escaneando um QR code. O histórico de conversas e os contatos não são afetados.
+:::
+
+:::warning Mudança no formato de JID
+O whatsapp-web.js usa `number@c.us` para contatos. O whatsmeow-node usa `number@s.whatsapp.net`. Atualize quaisquer JIDs armazenados no seu banco de dados.
+:::
+
+:::warning Tratamento de mídia
+O whatsapp-web.js oferece `msg.downloadMedia()` que retorna base64. O `downloadAny()` do whatsmeow-node salva em um arquivo temporário. Ajuste seu pipeline de mídia conforme necessário.
+:::
+
+<RelatedGuides slugs={["migrate-from-whatsapp-web-js", "send-notifications", "whatsmeow-in-node", "automate-group-messages"]} />

--- a/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/migrate-from-baileys.md
+++ b/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/migrate-from-baileys.md
@@ -1,0 +1,281 @@
+---
+title: "Como Substituir o Baileys pelo whatsmeow-node"
+sidebar_label: Migrar do Baileys
+sidebar_position: 10
+description: "Migre seu bot de WhatsApp do Baileys para o whatsmeow-node — comparação lado a lado, mapeamento de API e guia passo a passo de migração."
+keywords: [alternativa ao baileys, substituir baileys, baileys para whatsmeow, migração baileys, migração bot whatsapp nodejs, baileys vs whatsmeow]
+---
+
+import Head from '@docusaurus/Head';
+import {RelatedGuides} from '@site/src/components/RelatedGuides';
+
+<Head>
+  <meta property="og:image" content="https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/migrate-from-baileys.png" />
+  <meta name="twitter:image" content="https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/migrate-from-baileys.png" />
+  <script type="application/ld+json">
+    {JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "HowTo",
+      "name": "How to Replace Baileys with whatsmeow-node",
+      "description": "Migrate your WhatsApp bot from Baileys to whatsmeow-node — side-by-side code comparison, API mapping, and step-by-step migration guide.",
+      "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/migrate-from-baileys.png",
+      "step": [
+        {"@type": "HowToStep", "name": "Install whatsmeow-node", "text": "Replace @whiskeysockets/baileys with @whatsmeow-node/whatsmeow-node in your dependencies."},
+        {"@type": "HowToStep", "name": "Update Client Initialization", "text": "Replace makeWASocket with createClient. Switch from useMultiFileAuthState to a store path."},
+        {"@type": "HowToStep", "name": "Update Event Listeners", "text": "Replace ev.on('messages.upsert') with client.on('message'). Update event shapes to match whatsmeow-node."},
+        {"@type": "HowToStep", "name": "Update Message Sending", "text": "Replace sendMessage with the whatsmeow-node equivalent. Content shape is similar but key names differ."},
+        {"@type": "HowToStep", "name": "Update Group Operations", "text": "Replace groupCreate, groupMetadata, etc. with the whatsmeow-node equivalents."}
+      ]
+    })}
+  </script>
+  <script type="application/ld+json">
+    {JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "Article",
+      "headline": "How to Replace Baileys with whatsmeow-node",
+      "description": "Migrate your WhatsApp bot from Baileys to whatsmeow-node — side-by-side code comparison, API mapping, and step-by-step migration guide.",
+      "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/migrate-from-baileys.png",
+      "author": {"@type": "Organization", "name": "whatsmeow-node", "url": "https://nicastelo.github.io/whatsmeow-node/"},
+      "publisher": {"@type": "Organization", "name": "whatsmeow-node", "logo": {"@type": "ImageObject", "url": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/migrate-from-baileys.png"}}
+    })}
+  </script>
+</Head>
+
+![Como Substituir o Baileys pelo whatsmeow-node](/img/guides/pt-BR/migrate-from-baileys.png)
+![Como Substituir o Baileys pelo whatsmeow-node](/img/guides/pt-BR/migrate-from-baileys-light.png)
+
+# Como Substituir o Baileys pelo whatsmeow-node
+
+Se você usa o [Baileys](https://github.com/WhiskeySockets/Baileys) e está enfrentando problemas de manutenção, instabilidade de forks ou quer um upstream mais confiável, o whatsmeow-node é uma alternativa direta com uma superfície de API similar. Este guia mapeia os conceitos-chave e mostra como migrar.
+
+## Por Que Migrar?
+
+- **Upstream estável** — o whatsmeow é mantido pelo time Mautrix e usado em produção por milhares de bridges Matrix 24/7. Quando o WhatsApp muda o protocolo, as correções chegam rápido.
+- **Sem roleta de forks** — o Baileys já passou por múltiplos forks (adiwajshing, WhiskeySockets, outros). O whatsmeow-node encapsula uma única biblioteca Go estável.
+- **Menos memória** — ~10-20 MB vs ~50 MB típicos do Baileys.
+- **API tipada** — mais de 100 métodos async tipados com design TypeScript-first.
+
+Veja a [Comparação com Alternativas](/docs/comparison) para mais detalhes.
+
+## Passo 1: Instalar
+
+```bash
+# Remove Baileys
+npm uninstall @whiskeysockets/baileys
+
+# Install whatsmeow-node
+npm install @whatsmeow-node/whatsmeow-node
+```
+
+## Passo 2: Atualizar a Inicialização do Client
+
+### Baileys
+
+```typescript
+import makeWASocket, { useMultiFileAuthState } from "@whiskeysockets/baileys";
+
+const { state, saveCreds } = await useMultiFileAuthState("auth_info");
+const sock = makeWASocket({ auth: state });
+sock.ev.on("creds.update", saveCreds);
+```
+
+### whatsmeow-node
+
+```typescript
+import { createClient } from "@whatsmeow-node/whatsmeow-node";
+
+const client = createClient({ store: "session.db" });
+const { jid } = await client.init();
+await client.connect();
+```
+
+A persistência da sessão é automática — não precisa de callback `saveCreds`. A opção `store` aceita um caminho de arquivo (SQLite) ou uma string de conexão PostgreSQL.
+
+:::info
+Você precisará parear novamente (escanear QR code) após a troca. O estado de autenticação do Baileys não é compatível com sessões do whatsmeow.
+:::
+
+## Passo 3: Atualizar os Listeners de Eventos
+
+### Mensagens
+
+**Baileys:**
+```typescript
+sock.ev.on("messages.upsert", ({ messages }) => {
+  for (const msg of messages) {
+    if (msg.key.fromMe) continue;
+    const text = msg.message?.conversation
+      ?? msg.message?.extendedTextMessage?.text;
+    console.log(`${msg.pushName}: ${text}`);
+  }
+});
+```
+
+**whatsmeow-node:**
+```typescript
+client.on("message", ({ info, message }) => {
+  if (info.isFromMe) return;
+  const text =
+    (message.conversation as string) ??
+    (message.extendedTextMessage as { text?: string } | undefined)?.text;
+  console.log(`${info.pushName}: ${text}`);
+});
+```
+
+Diferenças principais:
+- Uma mensagem por evento (sem batch)
+- Metadados da mensagem ficam em `info`, conteúdo protobuf fica em `message`
+- `info.isFromMe` substitui `msg.key.fromMe`
+- `info.chat` substitui `msg.key.remoteJid`
+- `info.sender` substitui `msg.key.participant` (em grupos)
+
+### Conexão
+
+**Baileys:**
+```typescript
+sock.ev.on("connection.update", ({ connection, lastDisconnect }) => {
+  if (connection === "open") console.log("Connected!");
+  if (connection === "close") { /* handle reconnection */ }
+});
+```
+
+**whatsmeow-node:**
+```typescript
+client.on("connected", ({ jid }) => console.log(`Connected as ${jid}`));
+client.on("disconnected", () => console.log("Disconnected"));
+client.on("logged_out", ({ reason }) => console.error(`Logged out: ${reason}`));
+```
+
+Você não precisa de lógica manual de reconexão — o whatsmeow faz isso automaticamente.
+
+## Passo 4: Atualizar o Envio de Mensagens
+
+### Mensagem de texto
+
+**Baileys:**
+```typescript
+await sock.sendMessage(jid, { text: "Hello!" });
+```
+
+**whatsmeow-node:**
+```typescript
+await client.sendMessage(jid, { conversation: "Hello!" });
+```
+
+### Resposta com citação
+
+**Baileys:**
+```typescript
+await sock.sendMessage(jid, { text: "Reply!" }, { quoted: msg });
+```
+
+**whatsmeow-node:**
+```typescript
+await client.sendRawMessage(jid, {
+  extendedTextMessage: {
+    text: "Reply!",
+    contextInfo: {
+      stanzaId: info.id,
+      participant: info.sender,
+      quotedMessage: { conversation: originalText },
+    },
+  },
+});
+```
+
+### Mídia
+
+**Baileys:**
+```typescript
+await sock.sendMessage(jid, {
+  image: { url: "/path/to/photo.jpg" },
+  caption: "Check this out",
+});
+```
+
+**whatsmeow-node:**
+```typescript
+const media = await client.uploadMedia("/path/to/photo.jpg", "image");
+await client.sendRawMessage(jid, {
+  imageMessage: {
+    URL: media.URL,
+    directPath: media.directPath,
+    mediaKey: media.mediaKey,
+    fileEncSHA256: media.fileEncSHA256,
+    fileSHA256: media.fileSHA256,
+    fileLength: String(media.fileLength),
+    mimetype: "image/jpeg",
+    caption: "Check this out",
+  },
+});
+```
+
+O upload e o envio de mídia são etapas separadas no whatsmeow-node. Isso dá mais controle (ex.: fazer upload uma vez, enviar para vários chats).
+
+### Reações
+
+**Baileys:**
+```typescript
+await sock.sendMessage(jid, { react: { text: "👍", key: msg.key } });
+```
+
+**whatsmeow-node:**
+```typescript
+await client.sendReaction(jid, senderJid, messageId, "👍");
+```
+
+## Passo 5: Atualizar Operações de Grupo
+
+| Baileys | whatsmeow-node |
+|---------|----------------|
+| `sock.groupCreate(name, members)` | `client.createGroup(name, members)` |
+| `sock.groupMetadata(jid)` | `client.getGroupInfo(jid)` |
+| `sock.groupFetchAllParticipating()` | `client.getJoinedGroups()` |
+| `sock.groupUpdateSubject(jid, name)` | `client.setGroupName(jid, name)` |
+| `sock.groupUpdateDescription(jid, desc)` | `client.setGroupDescription(jid, desc)` |
+| `sock.groupSettingUpdate(jid, "announcement")` | `client.setGroupAnnounce(jid, true)` |
+| `sock.groupParticipantsUpdate(jid, [jid], "add")` | `client.updateGroupParticipants(jid, [jid], "add")` |
+| `sock.groupInviteCode(jid)` | `client.getGroupInviteLink(jid)` |
+| `sock.groupLeave(jid)` | `client.leaveGroup(jid)` |
+
+## Referência Rápida de API
+
+| Baileys | whatsmeow-node |
+|---------|----------------|
+| `makeWASocket()` | `createClient()` |
+| `sock.sendMessage(jid, content)` | `client.sendMessage(jid, content)` |
+| `sock.readMessages([key])` | `client.markRead([id], chat, sender)` |
+| `sock.sendPresenceUpdate("available")` | `client.sendPresence("available")` |
+| `sock.presenceSubscribe(jid)` | `client.subscribePresence(jid)` |
+| `sock.profilePictureUrl(jid)` | `client.getProfilePicture(jid)` |
+| `sock.updateBlockStatus(jid, "block")` | `client.updateBlocklist(jid, "block")` |
+| `sock.logout()` | `client.logout()` |
+
+## Checklist de Migração
+
+- [ ] Instalar `@whatsmeow-node/whatsmeow-node`, remover `@whiskeysockets/baileys`
+- [ ] Substituir `makeWASocket` por `createClient`
+- [ ] Remover `useMultiFileAuthState` — a sessão é tratada automaticamente
+- [ ] Atualizar listeners de eventos (`ev.on` por `client.on`, nomes de eventos diferentes)
+- [ ] Atualizar chamadas de `sendMessage` (`text` por `conversation`)
+- [ ] Atualizar envio de mídia (etapas separadas de upload + envio)
+- [ ] Atualizar operações de grupo (nomes dos métodos diferem levemente)
+- [ ] Remover lógica manual de reconexão — o whatsmeow reconecta automaticamente
+- [ ] Parear novamente via QR code (nova sessão necessária)
+- [ ] Testar todos os tipos de mensagem de ponta a ponta
+
+## Erros Comuns
+
+:::warning Nova sessão necessária
+O estado de autenticação do Baileys não pode ser migrado. Você precisa parear uma nova sessão escaneando o QR code. Seu histórico de conversas e contatos do WhatsApp não são afetados — apenas o vínculo do dispositivo é novo.
+:::
+
+:::warning `text` vs `conversation`
+O Baileys usa `{ text: "..." }` para mensagens. O whatsmeow-node usa `{ conversation: "..." }` — seguindo o nome do campo protobuf do WhatsApp.
+:::
+
+:::warning Casing dos campos proto
+Os campos da resposta do upload usam o casing exato do protobuf: `URL`, `fileSHA256`, `fileEncSHA256` — **não** camelCase. Usar o casing errado falha silenciosamente.
+:::
+
+<RelatedGuides slugs={["whatsmeow-in-node", "build-a-bot", "migrate-from-whatsapp-web-js"]} />

--- a/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/migrate-from-baileys.md
+++ b/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/migrate-from-baileys.md
@@ -16,15 +16,15 @@ import {RelatedGuides} from '@site/src/components/RelatedGuides';
     {JSON.stringify({
       "@context": "https://schema.org",
       "@type": "HowTo",
-      "name": "How to Replace Baileys with whatsmeow-node",
-      "description": "Migrate your WhatsApp bot from Baileys to whatsmeow-node — side-by-side code comparison, API mapping, and step-by-step migration guide.",
+      "name": "Como Substituir o Baileys pelo whatsmeow-node",
+      "description": "Migre seu bot de WhatsApp do Baileys para o whatsmeow-node — comparação lado a lado, mapeamento de API e guia passo a passo de migração.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/migrate-from-baileys.png",
       "step": [
-        {"@type": "HowToStep", "name": "Install whatsmeow-node", "text": "Replace @whiskeysockets/baileys with @whatsmeow-node/whatsmeow-node in your dependencies."},
-        {"@type": "HowToStep", "name": "Update Client Initialization", "text": "Replace makeWASocket with createClient. Switch from useMultiFileAuthState to a store path."},
-        {"@type": "HowToStep", "name": "Update Event Listeners", "text": "Replace ev.on('messages.upsert') with client.on('message'). Update event shapes to match whatsmeow-node."},
-        {"@type": "HowToStep", "name": "Update Message Sending", "text": "Replace sendMessage with the whatsmeow-node equivalent. Content shape is similar but key names differ."},
-        {"@type": "HowToStep", "name": "Update Group Operations", "text": "Replace groupCreate, groupMetadata, etc. with the whatsmeow-node equivalents."}
+        {"@type": "HowToStep", "name": "Instalar o whatsmeow-node", "text": "Substitua @whiskeysockets/baileys por @whatsmeow-node/whatsmeow-node nas suas dependências."},
+        {"@type": "HowToStep", "name": "Atualizar a Inicialização do Client", "text": "Substitua makeWASocket por createClient. Troque useMultiFileAuthState por um caminho de store."},
+        {"@type": "HowToStep", "name": "Atualizar os Listeners de Eventos", "text": "Substitua ev.on('messages.upsert') por client.on('message'). Atualize os formatos de evento para o padrão do whatsmeow-node."},
+        {"@type": "HowToStep", "name": "Atualizar o Envio de Mensagens", "text": "Substitua sendMessage pelo equivalente do whatsmeow-node. O formato do conteúdo é similar, mas os nomes dos campos diferem."},
+        {"@type": "HowToStep", "name": "Atualizar Operações de Grupo", "text": "Substitua groupCreate, groupMetadata, etc. pelos equivalentes do whatsmeow-node."}
       ]
     })}
   </script>
@@ -32,8 +32,8 @@ import {RelatedGuides} from '@site/src/components/RelatedGuides';
     {JSON.stringify({
       "@context": "https://schema.org",
       "@type": "Article",
-      "headline": "How to Replace Baileys with whatsmeow-node",
-      "description": "Migrate your WhatsApp bot from Baileys to whatsmeow-node — side-by-side code comparison, API mapping, and step-by-step migration guide.",
+      "headline": "Como Substituir o Baileys pelo whatsmeow-node",
+      "description": "Migre seu bot de WhatsApp do Baileys para o whatsmeow-node — comparação lado a lado, mapeamento de API e guia passo a passo de migração.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/migrate-from-baileys.png",
       "author": {"@type": "Organization", "name": "whatsmeow-node", "url": "https://nicastelo.github.io/whatsmeow-node/"},
       "publisher": {"@type": "Organization", "name": "whatsmeow-node", "logo": {"@type": "ImageObject", "url": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/migrate-from-baileys.png"}}

--- a/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/migrate-from-whatsapp-web-js.md
+++ b/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/migrate-from-whatsapp-web-js.md
@@ -1,0 +1,322 @@
+---
+title: "Como Substituir o whatsapp-web.js pelo whatsmeow-node"
+sidebar_label: Migrar do whatsapp-web.js
+sidebar_position: 11
+description: "Migre do whatsapp-web.js para o whatsmeow-node — elimine o Puppeteer, reduza a memória de 500 MB para 20 MB e tenha uma API async tipada."
+keywords: [alternativa ao whatsapp-web.js, substituir whatsapp-web.js, whatsapp-web.js para whatsmeow, migração whatsapp-web.js, bot whatsapp sem puppeteer, bot whatsapp sem navegador]
+---
+
+import Head from '@docusaurus/Head';
+import {RelatedGuides} from '@site/src/components/RelatedGuides';
+
+<Head>
+  <meta property="og:image" content="https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/migrate-from-whatsapp-web-js.png" />
+  <meta name="twitter:image" content="https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/migrate-from-whatsapp-web-js.png" />
+  <script type="application/ld+json">
+    {JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "HowTo",
+      "name": "How to Replace whatsapp-web.js with whatsmeow-node",
+      "description": "Migrate from whatsapp-web.js to whatsmeow-node — drop Puppeteer, cut memory from 500 MB to 20 MB, and get a typed async API.",
+      "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/migrate-from-whatsapp-web-js.png",
+      "step": [
+        {"@type": "HowToStep", "name": "Install whatsmeow-node", "text": "Replace whatsapp-web.js and puppeteer with @whatsmeow-node/whatsmeow-node."},
+        {"@type": "HowToStep", "name": "Update Client Initialization", "text": "Replace new Client() with createClient(). No LocalAuth or Puppeteer configuration needed."},
+        {"@type": "HowToStep", "name": "Update Event Listeners", "text": "Replace client.on('message') callback shapes and update message property access patterns."},
+        {"@type": "HowToStep", "name": "Update Message Sending", "text": "Replace client.sendMessage() with the whatsmeow-node sendMessage or sendRawMessage methods."},
+        {"@type": "HowToStep", "name": "Remove Browser Dependencies", "text": "Remove Puppeteer, Chromium, and any browser-related configuration from your project."}
+      ]
+    })}
+  </script>
+  <script type="application/ld+json">
+    {JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "Article",
+      "headline": "How to Replace whatsapp-web.js with whatsmeow-node",
+      "description": "Migrate from whatsapp-web.js to whatsmeow-node — drop Puppeteer, cut memory from 500 MB to 20 MB, and get a typed async API.",
+      "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/migrate-from-whatsapp-web-js.png",
+      "author": {"@type": "Organization", "name": "whatsmeow-node", "url": "https://nicastelo.github.io/whatsmeow-node/"},
+      "publisher": {"@type": "Organization", "name": "whatsmeow-node", "logo": {"@type": "ImageObject", "url": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/migrate-from-whatsapp-web-js.png"}}
+    })}
+  </script>
+</Head>
+
+![Como Substituir o whatsapp-web.js pelo whatsmeow-node](/img/guides/pt-BR/migrate-from-whatsapp-web-js.png)
+![Como Substituir o whatsapp-web.js pelo whatsmeow-node](/img/guides/pt-BR/migrate-from-whatsapp-web-js-light.png)
+
+# Como Substituir o whatsapp-web.js pelo whatsmeow-node
+
+O [whatsapp-web.js](https://github.com/pedroslopez/whatsapp-web.js) roda um navegador Chrome headless para automatizar o WhatsApp Web. Funciona, mas é pesado — 200-500 MB de RAM só para o navegador, startup lento, e quebra quando o WhatsApp atualiza o client web. O whatsmeow-node usa o protocolo nativo multi-dispositivo diretamente, sem precisar de navegador.
+
+## Por Que Migrar?
+
+| | whatsapp-web.js | whatsmeow-node |
+|---|---|---|
+| **Memória** | 200-500 MB (Chromium) | ~10-20 MB |
+| **Startup** | 5-15 segundos (iniciar navegador) | Menos de 1 segundo |
+| **Dependências** | Puppeteer + Chromium | Binário Go único (incluído) |
+| **Protocolo** | Automação do client web | Multi-dispositivo nativo |
+| **Estabilidade** | Quebra com atualizações do WhatsApp Web | Upstream estável (whatsmeow) |
+| **Imagem Docker** | ~1 GB+ (precisa do Chrome) | ~50 MB |
+| **TypeScript** | Tipos da comunidade | TypeScript nativo |
+
+## Passo 1: Instalar
+
+```bash
+# Remove whatsapp-web.js and Puppeteer
+npm uninstall whatsapp-web.js puppeteer
+
+# Install whatsmeow-node
+npm install @whatsmeow-node/whatsmeow-node
+```
+
+Você também pode remover qualquer dependência relacionada ao Chromium ou camadas Docker.
+
+## Passo 2: Atualizar a Inicialização do Client
+
+### whatsapp-web.js
+
+```javascript
+const { Client, LocalAuth } = require("whatsapp-web.js");
+
+const client = new Client({
+  authStrategy: new LocalAuth(),
+  puppeteer: {
+    headless: true,
+    args: ["--no-sandbox"],
+  },
+});
+
+client.on("qr", (qr) => {
+  qrcode.generate(qr, { small: true });
+});
+
+client.on("ready", () => {
+  console.log("Client is ready!");
+});
+
+client.initialize();
+```
+
+### whatsmeow-node
+
+```typescript
+import { createClient } from "@whatsmeow-node/whatsmeow-node";
+import qrcode from "qrcode-terminal";
+
+const client = createClient({ store: "session.db" });
+
+async function main() {
+  const { jid } = await client.init();
+
+  if (jid) {
+    await client.connect();
+    console.log("Client is ready!");
+  } else {
+    client.on("qr", ({ code }) => qrcode.generate(code, { small: true }));
+    await client.getQRChannel();
+    await client.connect();
+  }
+}
+
+main().catch(console.error);
+```
+
+Sem config de Puppeteer, sem auth strategy, sem `initialize()` — apenas `init()` + `connect()`.
+
+## Passo 3: Atualizar os Listeners de Eventos
+
+### Mensagens
+
+**whatsapp-web.js:**
+```javascript
+client.on("message", async (msg) => {
+  if (msg.fromMe) return;
+  console.log(`${msg.from}: ${msg.body}`);
+
+  if (msg.body === "!ping") {
+    await msg.reply("pong");
+  }
+});
+```
+
+**whatsmeow-node:**
+```typescript
+client.on("message", async ({ info, message }) => {
+  if (info.isFromMe) return;
+
+  const text =
+    (message.conversation as string) ??
+    (message.extendedTextMessage as { text?: string } | undefined)?.text;
+  if (!text) return;
+
+  console.log(`${info.chat}: ${text}`);
+
+  if (text === "!ping") {
+    await client.sendMessage(info.chat, { conversation: "pong" });
+  }
+});
+```
+
+Diferenças principais:
+- Sem atalho `msg.body` — o texto é extraído da mensagem protobuf
+- Sem `msg.reply()` — use `sendMessage()` ou `sendRawMessage()` com `contextInfo` para citações
+- `msg.from` vira `info.chat`, `msg.fromMe` vira `info.isFromMe`
+
+### Eventos de conexão
+
+**whatsapp-web.js:**
+```javascript
+client.on("ready", () => console.log("Ready"));
+client.on("disconnected", (reason) => console.log("Disconnected:", reason));
+```
+
+**whatsmeow-node:**
+```typescript
+client.on("connected", ({ jid }) => console.log(`Connected as ${jid}`));
+client.on("disconnected", () => console.log("Disconnected"));
+client.on("logged_out", ({ reason }) => console.error(`Logged out: ${reason}`));
+```
+
+## Passo 4: Atualizar o Envio de Mensagens
+
+### Texto
+
+**whatsapp-web.js:**
+```javascript
+await client.sendMessage(chatId, "Hello!");
+```
+
+**whatsmeow-node:**
+```typescript
+await client.sendMessage(jid, { conversation: "Hello!" });
+```
+
+### Resposta com citação
+
+**whatsapp-web.js:**
+```javascript
+await msg.reply("Got it!");
+```
+
+**whatsmeow-node:**
+```typescript
+await client.sendRawMessage(info.chat, {
+  extendedTextMessage: {
+    text: "Got it!",
+    contextInfo: {
+      stanzaId: info.id,
+      participant: info.sender,
+      quotedMessage: { conversation: originalText },
+    },
+  },
+});
+```
+
+### Mídia
+
+**whatsapp-web.js:**
+```javascript
+const media = MessageMedia.fromFilePath("/path/to/photo.jpg");
+await client.sendMessage(chatId, media, { caption: "Check this out" });
+```
+
+**whatsmeow-node:**
+```typescript
+const media = await client.uploadMedia("/path/to/photo.jpg", "image");
+await client.sendRawMessage(jid, {
+  imageMessage: {
+    URL: media.URL,
+    directPath: media.directPath,
+    mediaKey: media.mediaKey,
+    fileEncSHA256: media.fileEncSHA256,
+    fileSHA256: media.fileSHA256,
+    fileLength: String(media.fileLength),
+    mimetype: "image/jpeg",
+    caption: "Check this out",
+  },
+});
+```
+
+### Reações
+
+**whatsapp-web.js:**
+```javascript
+await msg.react("👍");
+```
+
+**whatsmeow-node:**
+```typescript
+await client.sendReaction(chat, sender, messageId, "👍");
+```
+
+## Passo 5: Atualizar Operações de Grupo
+
+| whatsapp-web.js | whatsmeow-node |
+|-----------------|----------------|
+| `client.createGroup(name, members)` | `client.createGroup(name, members)` |
+| `chat.fetchMessages()` | — (use o evento message) |
+| `groupChat.addParticipants([id])` | `client.updateGroupParticipants(jid, [id], "add")` |
+| `groupChat.removeParticipants([id])` | `client.updateGroupParticipants(jid, [id], "remove")` |
+| `groupChat.promoteParticipants([id])` | `client.updateGroupParticipants(jid, [id], "promote")` |
+| `groupChat.setSubject(name)` | `client.setGroupName(jid, name)` |
+| `groupChat.setDescription(desc)` | `client.setGroupDescription(jid, desc)` |
+| `groupChat.leave()` | `client.leaveGroup(jid)` |
+| `groupChat.getInviteCode()` | `client.getGroupInviteLink(jid)` |
+
+## Passo 6: Limpeza
+
+Depois de migrar, você pode remover do seu projeto:
+
+- Dependência `puppeteer` / `puppeteer-core`
+- Scripts de download do Chromium ou camadas Docker
+- Diretório `.wwebjs_auth/` (dados de sessão do LocalAuth)
+- Qualquer configuração de flags do Chrome como `--no-sandbox`, `--disable-gpu`
+- Setup de CI/CD específico para navegador (Xvfb, etc.)
+
+Suas imagens Docker vão diminuir drasticamente sem o Chromium.
+
+## Diferenças no Formato de JID
+
+O whatsapp-web.js usa `number@c.us` para contatos. O whatsmeow-node usa `number@s.whatsapp.net`:
+
+```typescript
+// whatsapp-web.js
+const chatId = "5512345678@c.us";
+
+// whatsmeow-node
+const jid = "5512345678@s.whatsapp.net";
+```
+
+Os JIDs de grupo continuam no mesmo formato: `120363XXXXX@g.us`.
+
+## Checklist de Migração
+
+- [ ] Instalar `@whatsmeow-node/whatsmeow-node`, remover `whatsapp-web.js` e `puppeteer`
+- [ ] Substituir `new Client()` por `createClient()`
+- [ ] Remover config do Puppeteer e `LocalAuth`
+- [ ] Atualizar listeners de eventos (nomes e formatos diferentes)
+- [ ] Substituir `msg.body` pela extração de mensagem protobuf
+- [ ] Substituir `msg.reply()` por `sendMessage()` / `sendRawMessage()`
+- [ ] Substituir `client.sendMessage(id, text)` por `sendMessage(jid, { conversation: text })`
+- [ ] Atualizar formato de JID: `@c.us` para `@s.whatsapp.net`
+- [ ] Atualizar envio de mídia (upload + envio separados)
+- [ ] Remover Chromium do Docker / CI
+- [ ] Parear novamente via QR code
+- [ ] Testar todos os tipos de mensagem de ponta a ponta
+
+## Erros Comuns
+
+:::warning Nova sessão necessária
+As sessões do whatsapp-web.js não podem ser migradas. Você precisa parear do zero escaneando o QR code. Seus dados do WhatsApp não são afetados.
+:::
+
+:::warning Sem `msg.body`
+O whatsapp-web.js oferece `msg.body` como conveniência. O whatsmeow-node entrega o protobuf bruto, então o texto pode estar em `message.conversation` ou `message.extendedTextMessage.text`. Sempre verifique ambos.
+:::
+
+:::warning Formato de JID
+O whatsapp-web.js usa `@c.us` para contatos. O whatsmeow-node usa `@s.whatsapp.net`. Se você tem JIDs armazenados, atualize-os.
+:::
+
+<RelatedGuides slugs={["whatsmeow-in-node", "build-a-bot", "migrate-from-baileys"]} />

--- a/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/migrate-from-whatsapp-web-js.md
+++ b/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/migrate-from-whatsapp-web-js.md
@@ -16,15 +16,15 @@ import {RelatedGuides} from '@site/src/components/RelatedGuides';
     {JSON.stringify({
       "@context": "https://schema.org",
       "@type": "HowTo",
-      "name": "How to Replace whatsapp-web.js with whatsmeow-node",
-      "description": "Migrate from whatsapp-web.js to whatsmeow-node — drop Puppeteer, cut memory from 500 MB to 20 MB, and get a typed async API.",
+      "name": "Como Substituir o whatsapp-web.js pelo whatsmeow-node",
+      "description": "Migre do whatsapp-web.js para o whatsmeow-node — elimine o Puppeteer, reduza a memória de 500 MB para 20 MB e tenha uma API async tipada.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/migrate-from-whatsapp-web-js.png",
       "step": [
-        {"@type": "HowToStep", "name": "Install whatsmeow-node", "text": "Replace whatsapp-web.js and puppeteer with @whatsmeow-node/whatsmeow-node."},
-        {"@type": "HowToStep", "name": "Update Client Initialization", "text": "Replace new Client() with createClient(). No LocalAuth or Puppeteer configuration needed."},
-        {"@type": "HowToStep", "name": "Update Event Listeners", "text": "Replace client.on('message') callback shapes and update message property access patterns."},
-        {"@type": "HowToStep", "name": "Update Message Sending", "text": "Replace client.sendMessage() with the whatsmeow-node sendMessage or sendRawMessage methods."},
-        {"@type": "HowToStep", "name": "Remove Browser Dependencies", "text": "Remove Puppeteer, Chromium, and any browser-related configuration from your project."}
+        {"@type": "HowToStep", "name": "Instalar o whatsmeow-node", "text": "Substitua whatsapp-web.js e puppeteer por @whatsmeow-node/whatsmeow-node."},
+        {"@type": "HowToStep", "name": "Atualizar a Inicialização do Client", "text": "Substitua new Client() por createClient(). Nenhuma configuração de LocalAuth ou Puppeteer é necessária."},
+        {"@type": "HowToStep", "name": "Atualizar os Listeners de Eventos", "text": "Substitua os formatos de callback do client.on('message') e atualize os padrões de acesso às propriedades da mensagem."},
+        {"@type": "HowToStep", "name": "Atualizar o Envio de Mensagens", "text": "Substitua client.sendMessage() pelos métodos sendMessage ou sendRawMessage do whatsmeow-node."},
+        {"@type": "HowToStep", "name": "Remover Dependências de Navegador", "text": "Remova Puppeteer, Chromium e qualquer configuração relacionada a navegador do seu projeto."}
       ]
     })}
   </script>
@@ -32,8 +32,8 @@ import {RelatedGuides} from '@site/src/components/RelatedGuides';
     {JSON.stringify({
       "@context": "https://schema.org",
       "@type": "Article",
-      "headline": "How to Replace whatsapp-web.js with whatsmeow-node",
-      "description": "Migrate from whatsapp-web.js to whatsmeow-node — drop Puppeteer, cut memory from 500 MB to 20 MB, and get a typed async API.",
+      "headline": "Como Substituir o whatsapp-web.js pelo whatsmeow-node",
+      "description": "Migre do whatsapp-web.js para o whatsmeow-node — elimine o Puppeteer, reduza a memória de 500 MB para 20 MB e tenha uma API async tipada.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/migrate-from-whatsapp-web-js.png",
       "author": {"@type": "Organization", "name": "whatsmeow-node", "url": "https://nicastelo.github.io/whatsmeow-node/"},
       "publisher": {"@type": "Organization", "name": "whatsmeow-node", "logo": {"@type": "ImageObject", "url": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/migrate-from-whatsapp-web-js.png"}}

--- a/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/pair-whatsapp.md
+++ b/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/pair-whatsapp.md
@@ -19,10 +19,10 @@ import Head from '@docusaurus/Head';
       "description": "Vincule uma conta WhatsApp ao seu app Node.js usando QR code ou código por número de telefone. Inclui persistência de sessão e reconexão.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/pair-whatsapp.png",
       "step": [
-        {"@type": "HowToStep", "name": "QR Code Pairing", "text": "Call getQRChannel() then connect(). Listen for the qr event and render the code with qrcode-terminal."},
-        {"@type": "HowToStep", "name": "Phone Number Pairing", "text": "Call connect() first, then pairCode(phoneNumber). The user enters the 8-digit code in WhatsApp."},
-        {"@type": "HowToStep", "name": "Session Persistence", "text": "The session is stored in the database. On next run, init() returns the stored JID and you skip pairing."},
-        {"@type": "HowToStep", "name": "Choose a Store", "text": "Use SQLite (session.db) for development or PostgreSQL for production."}
+        {"@type": "HowToStep", "name": "Pareamento por QR Code", "text": "Chame getQRChannel() e depois connect(). Escute o evento qr e renderize o código com qrcode-terminal."},
+        {"@type": "HowToStep", "name": "Pareamento por Número de Telefone", "text": "Chame connect() primeiro, depois pairCode(phoneNumber). O usuário digita o código de 8 dígitos no WhatsApp."},
+        {"@type": "HowToStep", "name": "Persistência de Sessão", "text": "A sessão é armazenada no banco de dados. Na próxima execução, init() retorna o JID armazenado e você pula o pareamento."},
+        {"@type": "HowToStep", "name": "Escolher um Store", "text": "Use SQLite (session.db) para desenvolvimento ou PostgreSQL para produção."}
       ]
     })}
   </script>

--- a/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/poll-bot.md
+++ b/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/poll-bot.md
@@ -1,0 +1,350 @@
+---
+title: "Como Criar um Bot de Enquete no WhatsApp"
+sidebar_label: Bot de Enquete
+sidebar_position: 19
+description: "Crie e gerencie enquetes no WhatsApp programaticamente com Node.js — envie enquetes, leia votos, anuncie resultados e construa bots interativos com whatsmeow-node."
+keywords: [bot enquete whatsapp, criar enquete whatsapp api, enquete whatsapp nodejs, voto enquete whatsapp api, bot enquete whatsapp typescript]
+---
+
+import Head from '@docusaurus/Head';
+import {RelatedGuides} from '@site/src/components/RelatedGuides';
+
+<Head>
+  <meta property="og:image" content="https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/poll-bot.png" />
+  <meta name="twitter:image" content="https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/poll-bot.png" />
+  <script type="application/ld+json">
+    {JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "HowTo",
+      "name": "How to Create a WhatsApp Poll Bot",
+      "description": "Create and manage WhatsApp polls programmatically with Node.js — send polls, read votes, announce results, and build interactive group bots with whatsmeow-node.",
+      "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/poll-bot.png",
+      "step": [
+        {"@type": "HowToStep", "name": "Create a Poll", "text": "Use sendPollCreation() with a question, options array, and max selectable count."},
+        {"@type": "HowToStep", "name": "Listen for Votes", "text": "Handle incoming poll vote messages and decrypt them with decryptPollVote()."},
+        {"@type": "HowToStep", "name": "Track Results", "text": "Store votes in a Map and tally results per poll."},
+        {"@type": "HowToStep", "name": "Announce Results", "text": "Send a summary message with the vote counts when the poll closes."}
+      ]
+    })}
+  </script>
+  <script type="application/ld+json">
+    {JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "Article",
+      "headline": "How to Create a WhatsApp Poll Bot",
+      "description": "Create and manage WhatsApp polls programmatically with Node.js — send polls, read votes, announce results, and build interactive group bots with whatsmeow-node.",
+      "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/poll-bot.png",
+      "author": {"@type": "Organization", "name": "whatsmeow-node", "url": "https://nicastelo.github.io/whatsmeow-node/"},
+      "publisher": {"@type": "Organization", "name": "whatsmeow-node", "logo": {"@type": "ImageObject", "url": "https://nicastelo.github.io/whatsmeow-node/img/image.png"}}
+    })}
+  </script>
+</Head>
+
+![Como Criar um Bot de Enquete no WhatsApp](/img/guides/pt-BR/poll-bot.png)
+![Como Criar um Bot de Enquete no WhatsApp](/img/guides/pt-BR/poll-bot-light.png)
+
+# Como Criar um Bot de Enquete no WhatsApp
+
+O whatsmeow-node permite criar enquetes, receber votos criptografados, descriptografá-los e contabilizar resultados — tudo programaticamente. Isso é ótimo para bots de grupo que fazem votações, pesquisas ou fluxos de tomada de decisão.
+
+## Pré-requisitos
+
+- Uma sessão pareada do whatsmeow-node ([Como Parear](pair-whatsapp))
+- Um grupo para testar (enquetes funcionam melhor em chats de grupo)
+
+## Passo 1: Criar uma Enquete
+
+```typescript
+const resp = await client.sendPollCreation(
+  groupJid,
+  "Where should we eat?",         // question
+  ["Pizza", "Sushi", "Tacos"],    // options
+  1,                               // max selectable (1 = single choice)
+);
+
+console.log(`Poll sent with ID: ${resp.id}`);
+```
+
+Defina `selectableCount` para permitir múltiplas seleções:
+
+```typescript
+// Multi-select poll — voters can pick up to 3
+await client.sendPollCreation(
+  groupJid,
+  "Which topics should we cover?",
+  ["Frontend", "Backend", "DevOps", "Mobile", "AI"],
+  3,
+);
+```
+
+## Passo 2: Ouvir os Votos
+
+Os votos das enquetes chegam como eventos `message` com dados criptografados. Use `decryptPollVote()` para lê-los.
+
+:::warning Hashes dos votos
+`decryptPollVote()` retorna `selectedOptions` como **hashes SHA-256** (codificados em base64), não o texto das opções. Você precisa fazer o hash das suas opções conhecidas e comparar para identificar quais opções foram selecionadas.
+:::
+
+```typescript
+import { createHash } from "node:crypto";
+
+// Hash an option name the same way WhatsApp does
+function hashOption(option: string): string {
+  return createHash("sha256").update(option).digest("base64");
+}
+
+client.on("message", async ({ info, message }) => {
+  const pollUpdate = message.pollUpdateMessage as Record<string, unknown> | undefined;
+  if (!pollUpdate) return;
+
+  // Get the poll message ID from the poll update
+  const pollKey = pollUpdate.pollCreationMessageKey as { id?: string } | undefined;
+  const pollId = pollKey?.id;
+  if (!pollId) return;
+
+  try {
+    const vote = await client.decryptPollVote(
+        info as unknown as Record<string, unknown>,
+        message,
+      );
+    const hashes = (vote.selectedOptions ?? []) as string[];
+    console.log(`${info.sender} voted (${hashes.length} options)`);
+  } catch (err) {
+    console.error("Failed to decrypt poll vote:", err);
+  }
+});
+```
+
+## Passo 3: Rastrear Resultados
+
+Armazene as enquetes com um lookup hash-para-opção para resolver os hashes dos votos de volta para os nomes das opções:
+
+```typescript
+import { createHash } from "node:crypto";
+
+function hashOption(option: string): string {
+  return createHash("sha256").update(option).digest("base64");
+}
+
+type PollData = {
+  question: string;
+  hashToOption: Map<string, string>; // SHA-256 hash → option name
+  results: Map<string, string[]>;    // option name → voter JIDs
+};
+
+const polls = new Map<string, PollData>();
+
+// When creating a poll, store option hashes
+async function createPoll(groupJid: string, question: string, options: string[]) {
+  const resp = await client.sendPollCreation(groupJid, question, options, 1);
+
+  const hashToOption = new Map<string, string>();
+  const results = new Map<string, string[]>();
+  for (const opt of options) {
+    hashToOption.set(hashOption(opt), opt);
+    results.set(opt, []);
+  }
+
+  polls.set(resp.id, { question, hashToOption, results });
+  return resp;
+}
+
+// When receiving a vote, resolve hashes and tally
+function recordVote(pollId: string, voter: string, selectedHashes: string[]) {
+  const poll = polls.get(pollId);
+  if (!poll) return;
+
+  // Remove previous votes from this voter
+  for (const [, voters] of poll.results) {
+    const idx = voters.indexOf(voter);
+    if (idx !== -1) voters.splice(idx, 1);
+  }
+
+  // Resolve hashes to option names and add votes
+  for (const hash of selectedHashes) {
+    const option = poll.hashToOption.get(hash);
+    if (option) {
+      poll.results.get(option)?.push(voter);
+    }
+  }
+}
+```
+
+## Passo 4: Anunciar Resultados
+
+Envie um resumo com o comando `!results`:
+
+```typescript
+function formatResults(pollId: string): string | null {
+  const poll = polls.get(pollId);
+  if (!poll) return null;
+
+  let text = `Poll: ${poll.question}\n\n`;
+
+  const sorted = [...poll.results.entries()].sort((a, b) => b[1].length - a[1].length);
+
+  for (const [option, voters] of sorted) {
+    const bar = "█".repeat(voters.length);
+    text += `${option}: ${bar} ${voters.length}\n`;
+  }
+
+  const total = sorted.reduce((sum, [, v]) => sum + v.length, 0);
+  text += `\nTotal votes: ${total}`;
+
+  return text;
+}
+```
+
+## Exemplo Completo
+
+Um bot de grupo que trata comandos `!poll` e `!results`:
+
+```typescript
+import { createClient } from "@whatsmeow-node/whatsmeow-node";
+import { createHash } from "node:crypto";
+
+const client = createClient({ store: "session.db" });
+
+function hashOption(option: string): string {
+  return createHash("sha256").update(option).digest("base64");
+}
+
+type PollData = {
+  question: string;
+  chat: string;
+  hashToOption: Map<string, string>;
+  results: Map<string, string[]>;
+};
+
+const polls = new Map<string, PollData>();
+let lastPollId: string | null = null;
+
+client.on("message", async ({ info, message }) => {
+  if (info.isFromMe) return;
+
+  // Handle poll votes
+  const pollUpdate = message.pollUpdateMessage as Record<string, unknown> | undefined;
+  if (pollUpdate) {
+    const pollKey = pollUpdate.pollCreationMessageKey as { id?: string } | undefined;
+    const pollId = pollKey?.id;
+    if (!pollId) return;
+
+    const poll = polls.get(pollId);
+    if (!poll) return;
+
+    try {
+      const vote = await client.decryptPollVote(
+        info as unknown as Record<string, unknown>,
+        message,
+      );
+      const selectedHashes = (vote.selectedOptions ?? []) as string[];
+
+      // Remove previous votes from this voter
+      for (const [, voters] of poll.results) {
+        const idx = voters.indexOf(info.sender);
+        if (idx !== -1) voters.splice(idx, 1);
+      }
+
+      // Resolve hashes to option names and tally
+      for (const hash of selectedHashes) {
+        const option = poll.hashToOption.get(hash);
+        if (option) {
+          poll.results.get(option)?.push(info.sender);
+        }
+      }
+    } catch {
+      // Ignore decryption errors for polls we don't track
+    }
+    return;
+  }
+
+  // Handle text commands
+  const text =
+    (message.conversation as string) ??
+    (message.extendedTextMessage as { text?: string } | undefined)?.text;
+  if (!text?.startsWith("!")) return;
+
+  // !poll Where should we eat? | Pizza | Sushi | Tacos
+  if (text.startsWith("!poll ")) {
+    const parts = text.slice(6).split("|").map((s) => s.trim());
+    if (parts.length < 3) {
+      await client.sendMessage(info.chat, {
+        conversation: "Usage: !poll Question | Option 1 | Option 2 | ...",
+      });
+      return;
+    }
+
+    const [question, ...options] = parts;
+    const resp = await client.sendPollCreation(info.chat, question, options, 1);
+
+    const hashToOption = new Map<string, string>();
+    const results = new Map<string, string[]>();
+    for (const opt of options) {
+      hashToOption.set(hashOption(opt), opt);
+      results.set(opt, []);
+    }
+    polls.set(resp.id, { question, chat: info.chat, hashToOption, results });
+    lastPollId = resp.id;
+
+    return;
+  }
+
+  // !results — show results for the last poll
+  if (text === "!results") {
+    if (!lastPollId || !polls.has(lastPollId)) {
+      await client.sendMessage(info.chat, {
+        conversation: "No active poll. Create one with !poll",
+      });
+      return;
+    }
+
+    const poll = polls.get(lastPollId)!;
+    let summary = `Poll: ${poll.question}\n\n`;
+    const sorted = [...poll.results.entries()].sort((a, b) => b[1].length - a[1].length);
+    for (const [option, voters] of sorted) {
+      summary += `${option}: ${"█".repeat(voters.length)} ${voters.length}\n`;
+    }
+    const total = sorted.reduce((sum, [, v]) => sum + v.length, 0);
+    summary += `\nTotal votes: ${total}`;
+
+    await client.sendMessage(info.chat, { conversation: summary });
+    return;
+  }
+});
+
+async function main() {
+  const { jid } = await client.init();
+  if (!jid) {
+    console.error("Not paired!");
+    process.exit(1);
+  }
+  await client.connect();
+  await client.sendPresence("available");
+  console.log("Poll bot is online! Commands: !poll, !results");
+
+  process.on("SIGINT", async () => {
+    await client.sendPresence("unavailable");
+    await client.disconnect();
+    client.close();
+    process.exit(0);
+  });
+}
+
+main().catch(console.error);
+```
+
+## Erros Comuns
+
+:::warning Votos das enquetes são criptografados
+Você precisa chamar `decryptPollVote()` para ler os votos. A `pollUpdateMessage` bruta contém dados criptografados que são ilegíveis sem descriptografia.
+:::
+
+:::warning Resultados em memória
+O exemplo armazena dados da enquete em um `Map` que é perdido ao reiniciar. Para produção, persista enquetes e votos em um banco de dados.
+:::
+
+:::warning Loops de eco
+Sempre verifique `info.isFromMe`. O bot cria enquetes que disparam eventos de mensagem — sem essa verificação, ele poderia reagir às próprias enquetes.
+:::
+
+<RelatedGuides slugs={["automate-group-messages", "build-a-bot", "send-messages-typescript"]} />

--- a/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/poll-bot.md
+++ b/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/poll-bot.md
@@ -16,14 +16,14 @@ import {RelatedGuides} from '@site/src/components/RelatedGuides';
     {JSON.stringify({
       "@context": "https://schema.org",
       "@type": "HowTo",
-      "name": "How to Create a WhatsApp Poll Bot",
-      "description": "Create and manage WhatsApp polls programmatically with Node.js — send polls, read votes, announce results, and build interactive group bots with whatsmeow-node.",
+      "name": "Como Criar um Bot de Enquete no WhatsApp",
+      "description": "Crie e gerencie enquetes no WhatsApp programaticamente com Node.js — envie enquetes, leia votos, anuncie resultados e construa bots interativos com whatsmeow-node.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/poll-bot.png",
       "step": [
-        {"@type": "HowToStep", "name": "Create a Poll", "text": "Use sendPollCreation() with a question, options array, and max selectable count."},
-        {"@type": "HowToStep", "name": "Listen for Votes", "text": "Handle incoming poll vote messages and decrypt them with decryptPollVote()."},
-        {"@type": "HowToStep", "name": "Track Results", "text": "Store votes in a Map and tally results per poll."},
-        {"@type": "HowToStep", "name": "Announce Results", "text": "Send a summary message with the vote counts when the poll closes."}
+        {"@type": "HowToStep", "name": "Criar uma Enquete", "text": "Use sendPollCreation() com uma pergunta, array de opções e quantidade máxima de seleções."},
+        {"@type": "HowToStep", "name": "Ouvir os Votos", "text": "Trate mensagens de voto de enquete recebidas e descriptografe-as com decryptPollVote()."},
+        {"@type": "HowToStep", "name": "Rastrear Resultados", "text": "Armazene os votos em um Map e contabilize os resultados por enquete."},
+        {"@type": "HowToStep", "name": "Anunciar Resultados", "text": "Envie uma mensagem de resumo com a contagem de votos quando a enquete encerrar."}
       ]
     })}
   </script>
@@ -31,8 +31,8 @@ import {RelatedGuides} from '@site/src/components/RelatedGuides';
     {JSON.stringify({
       "@context": "https://schema.org",
       "@type": "Article",
-      "headline": "How to Create a WhatsApp Poll Bot",
-      "description": "Create and manage WhatsApp polls programmatically with Node.js — send polls, read votes, announce results, and build interactive group bots with whatsmeow-node.",
+      "headline": "Como Criar um Bot de Enquete no WhatsApp",
+      "description": "Crie e gerencie enquetes no WhatsApp programaticamente com Node.js — envie enquetes, leia votos, anuncie resultados e construa bots interativos com whatsmeow-node.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/poll-bot.png",
       "author": {"@type": "Organization", "name": "whatsmeow-node", "url": "https://nicastelo.github.io/whatsmeow-node/"},
       "publisher": {"@type": "Organization", "name": "whatsmeow-node", "logo": {"@type": "ImageObject", "url": "https://nicastelo.github.io/whatsmeow-node/img/image.png"}}

--- a/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/schedule-messages.md
+++ b/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/schedule-messages.md
@@ -1,0 +1,273 @@
+---
+title: "Como Agendar Mensagens no WhatsApp com Node.js"
+sidebar_label: Agendar Mensagens
+sidebar_position: 18
+description: "Agende mensagens no WhatsApp para enviar em um horário específico com Node.js — envios com delay, lembretes recorrentes e agendamento com cron usando whatsmeow-node."
+keywords: [agendar mensagens whatsapp nodejs, whatsapp mensagens agendadas api, whatsapp cron job, mensagem whatsapp com delay, bot lembrete whatsapp nodejs]
+---
+
+import Head from '@docusaurus/Head';
+import {RelatedGuides} from '@site/src/components/RelatedGuides';
+
+<Head>
+  <meta property="og:image" content="https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/schedule-messages.png" />
+  <meta name="twitter:image" content="https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/schedule-messages.png" />
+  <script type="application/ld+json">
+    {JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "HowTo",
+      "name": "How to Schedule WhatsApp Messages with Node.js",
+      "description": "Schedule WhatsApp messages to send at a specific time with Node.js — delayed sends, recurring reminders, and cron-based scheduling using whatsmeow-node.",
+      "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/schedule-messages.png",
+      "step": [
+        {"@type": "HowToStep", "name": "Send a Delayed Message", "text": "Use setTimeout to send a message after a delay."},
+        {"@type": "HowToStep", "name": "Schedule at a Specific Time", "text": "Calculate the delay from now until the target time and use setTimeout."},
+        {"@type": "HowToStep", "name": "Set Up Recurring Messages", "text": "Use node-cron to send messages on a cron schedule — daily reminders, weekly reports."},
+        {"@type": "HowToStep", "name": "Build a User-Facing Scheduler", "text": "Let users schedule messages via WhatsApp commands like !remind 30m Take a break."}
+      ]
+    })}
+  </script>
+  <script type="application/ld+json">
+    {JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "Article",
+      "headline": "How to Schedule WhatsApp Messages with Node.js",
+      "description": "Schedule WhatsApp messages to send at a specific time with Node.js — delayed sends, recurring reminders, and cron-based scheduling using whatsmeow-node.",
+      "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/schedule-messages.png",
+      "author": {"@type": "Organization", "name": "whatsmeow-node", "url": "https://nicastelo.github.io/whatsmeow-node/"},
+      "publisher": {"@type": "Organization", "name": "whatsmeow-node", "logo": {"@type": "ImageObject", "url": "https://nicastelo.github.io/whatsmeow-node/img/image.png"}}
+    })}
+  </script>
+</Head>
+
+![Como Agendar Mensagens no WhatsApp com Node.js](/img/guides/pt-BR/schedule-messages.png)
+![Como Agendar Mensagens no WhatsApp com Node.js](/img/guides/pt-BR/schedule-messages-light.png)
+
+# Como Agendar Mensagens no WhatsApp com Node.js
+
+O WhatsApp não tem uma API nativa de agendamento, mas você pode construir uma com whatsmeow-node e ferramentas padrão de agendamento do Node.js — `setTimeout` para delays únicos, `node-cron` para mensagens recorrentes, ou uma fila com banco de dados para persistência.
+
+## Pré-requisitos
+
+- Uma sessão pareada do whatsmeow-node ([Como Parear](pair-whatsapp))
+- Para agendamentos recorrentes: `npm install node-cron`
+
+## Enviar uma Mensagem com Delay
+
+A abordagem mais simples — envie uma mensagem após um delay:
+
+```typescript
+function sendLater(jid: string, message: string, delayMs: number) {
+  setTimeout(async () => {
+    await client.sendMessage(jid, { conversation: message });
+    console.log(`Sent scheduled message to ${jid}`);
+  }, delayMs);
+}
+
+// Send in 30 minutes
+sendLater("5512345678@s.whatsapp.net", "Time's up!", 30 * 60 * 1000);
+```
+
+## Agendar para um Horário Específico
+
+Calcule o delay entre agora e o horário desejado:
+
+```typescript
+function sendAt(jid: string, message: string, date: Date) {
+  const delay = date.getTime() - Date.now();
+
+  if (delay <= 0) {
+    console.error("Scheduled time is in the past");
+    return;
+  }
+
+  console.log(`Scheduled for ${date.toLocaleString()} (in ${Math.round(delay / 1000)}s)`);
+
+  setTimeout(async () => {
+    await client.sendMessage(jid, { conversation: message });
+  }, delay);
+}
+
+// Send tomorrow at 9 AM
+const tomorrow9am = new Date();
+tomorrow9am.setDate(tomorrow9am.getDate() + 1);
+tomorrow9am.setHours(9, 0, 0, 0);
+
+sendAt("5512345678@s.whatsapp.net", "Good morning! Don't forget the meeting at 10.", tomorrow9am);
+```
+
+## Configurar Mensagens Recorrentes com Cron
+
+Use `node-cron` para agendamentos recorrentes:
+
+```bash
+npm install node-cron
+```
+
+```typescript
+import cron from "node-cron";
+
+// Every weekday at 8:55 AM — "standup in 5 minutes"
+cron.schedule("55 8 * * 1-5", async () => {
+  const groupJid = "120363XXXXX@g.us";
+  await client.sendMessage(groupJid, {
+    conversation: "Standup in 5 minutes!",
+  });
+});
+
+// Every Monday at 9 AM — weekly report
+cron.schedule("0 9 * * 1", async () => {
+  const reportChat = "5512345678@s.whatsapp.net";
+  await client.sendMessage(reportChat, {
+    conversation: "Weekly report is ready: https://example.com/reports/latest",
+  });
+});
+
+// First day of every month — billing reminder
+cron.schedule("0 10 1 * *", async () => {
+  const billingGroup = "120363YYYYY@g.us";
+  await client.sendMessage(billingGroup, {
+    conversation: "Reminder: invoices are due by the 5th",
+  });
+});
+```
+
+:::info Sintaxe cron
+O `node-cron` usa o formato cron padrão: `minuto hora dia-do-mês mês dia-da-semana`. Use [crontab.guru](https://crontab.guru/) para criar expressões.
+:::
+
+## Criar um Agendador para o Usuário
+
+Permita que os usuários agendem lembretes via comandos no WhatsApp:
+
+```typescript
+client.on("message", async ({ info, message }) => {
+  if (info.isFromMe) return;
+
+  const text =
+    (message.conversation as string) ??
+    (message.extendedTextMessage as { text?: string } | undefined)?.text;
+  if (!text?.startsWith("!remind")) return;
+
+  // Parse: !remind 30m Take a break
+  const match = text.match(/^!remind\s+(\d+)(m|h|s)\s+(.+)$/);
+  if (!match) {
+    await client.sendMessage(info.chat, {
+      conversation: "Usage: !remind <number><m|h|s> <message>\nExample: !remind 30m Take a break",
+    });
+    return;
+  }
+
+  const [, amount, unit, reminder] = match;
+  const multiplier = { s: 1000, m: 60_000, h: 3_600_000 }[unit]!;
+  const delayMs = parseInt(amount) * multiplier;
+
+  setTimeout(async () => {
+    await client.sendRawMessage(info.chat, {
+      extendedTextMessage: {
+        text: `Reminder: ${reminder}`,
+        contextInfo: {
+          mentionedJid: [info.sender],
+        },
+      },
+    });
+  }, delayMs);
+
+  const delayText = `${amount}${unit}`;
+  await client.sendMessage(info.chat, {
+    conversation: `Got it! I'll remind you in ${delayText}: "${reminder}"`,
+  });
+});
+```
+
+## Exemplo Completo
+
+Um bot de agendamento com comandos `!remind` e um cron diário:
+
+```typescript
+import { createClient } from "@whatsmeow-node/whatsmeow-node";
+import cron from "node-cron";
+
+const client = createClient({ store: "session.db" });
+
+// Daily standup reminder
+cron.schedule("55 8 * * 1-5", async () => {
+  const group = "120363XXXXX@g.us";
+  await client.sendMessage(group, {
+    conversation: "Standup in 5 minutes!",
+  });
+});
+
+// User-facing !remind command
+client.on("message", async ({ info, message }) => {
+  if (info.isFromMe) return;
+
+  const text =
+    (message.conversation as string) ??
+    (message.extendedTextMessage as { text?: string } | undefined)?.text;
+  if (!text?.startsWith("!remind")) return;
+
+  const match = text.match(/^!remind\s+(\d+)(m|h|s)\s+(.+)$/);
+  if (!match) {
+    await client.sendMessage(info.chat, {
+      conversation: "Usage: !remind <number><m|h|s> <message>\nExample: !remind 30m Take a break",
+    });
+    return;
+  }
+
+  const [, amount, unit, reminder] = match;
+  const multiplier = { s: 1000, m: 60_000, h: 3_600_000 }[unit]!;
+  const delayMs = parseInt(amount) * multiplier;
+
+  setTimeout(async () => {
+    await client.sendRawMessage(info.chat, {
+      extendedTextMessage: {
+        text: `Reminder: ${reminder}`,
+        contextInfo: {
+          mentionedJid: [info.sender],
+        },
+      },
+    });
+  }, delayMs);
+
+  await client.sendMessage(info.chat, {
+    conversation: `I'll remind you in ${amount}${unit}: "${reminder}"`,
+  });
+});
+
+async function main() {
+  const { jid } = await client.init();
+  if (!jid) {
+    console.error("Not paired!");
+    process.exit(1);
+  }
+  await client.connect();
+  await client.sendPresence("available");
+  console.log("Scheduler bot is online!");
+
+  process.on("SIGINT", async () => {
+    await client.sendPresence("unavailable");
+    await client.disconnect();
+    client.close();
+    process.exit(0);
+  });
+}
+
+main().catch(console.error);
+```
+
+## Erros Comuns
+
+:::warning Agendamentos em memória são perdidos ao reiniciar
+Os agendamentos via `setTimeout` e `node-cron` vivem na memória. Se o processo reiniciar, os lembretes pendentes são perdidos. Para produção, persista os agendamentos em um banco de dados e recarregue-os na inicialização.
+:::
+
+:::warning Fuso horário
+O `node-cron` usa o fuso horário do servidor por padrão. Defina-o explicitamente com a opção `timezone` se seus usuários estão em fusos diferentes: `cron.schedule("0 9 * * *", fn, { timezone: "America/Sao_Paulo" })`.
+:::
+
+:::warning Rate limiting
+Se um cron job envia para muitos destinatários, espaçe os envios. Veja [Rate Limiting](/docs/rate-limiting).
+:::
+
+<RelatedGuides slugs={["send-notifications", "automate-group-messages", "build-a-bot"]} />

--- a/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/schedule-messages.md
+++ b/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/schedule-messages.md
@@ -16,14 +16,14 @@ import {RelatedGuides} from '@site/src/components/RelatedGuides';
     {JSON.stringify({
       "@context": "https://schema.org",
       "@type": "HowTo",
-      "name": "How to Schedule WhatsApp Messages with Node.js",
-      "description": "Schedule WhatsApp messages to send at a specific time with Node.js — delayed sends, recurring reminders, and cron-based scheduling using whatsmeow-node.",
+      "name": "Como Agendar Mensagens no WhatsApp com Node.js",
+      "description": "Agende mensagens no WhatsApp para enviar em um horário específico com Node.js — envios com delay, lembretes recorrentes e agendamento com cron usando whatsmeow-node.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/schedule-messages.png",
       "step": [
-        {"@type": "HowToStep", "name": "Send a Delayed Message", "text": "Use setTimeout to send a message after a delay."},
-        {"@type": "HowToStep", "name": "Schedule at a Specific Time", "text": "Calculate the delay from now until the target time and use setTimeout."},
-        {"@type": "HowToStep", "name": "Set Up Recurring Messages", "text": "Use node-cron to send messages on a cron schedule — daily reminders, weekly reports."},
-        {"@type": "HowToStep", "name": "Build a User-Facing Scheduler", "text": "Let users schedule messages via WhatsApp commands like !remind 30m Take a break."}
+        {"@type": "HowToStep", "name": "Enviar uma Mensagem com Delay", "text": "Use setTimeout para enviar uma mensagem após um delay."},
+        {"@type": "HowToStep", "name": "Agendar para um Horário Específico", "text": "Calcule o delay entre agora e o horário desejado e use setTimeout."},
+        {"@type": "HowToStep", "name": "Configurar Mensagens Recorrentes", "text": "Use node-cron para enviar mensagens em um agendamento cron — lembretes diários, relatórios semanais."},
+        {"@type": "HowToStep", "name": "Criar um Agendador para o Usuário", "text": "Permita que os usuários agendem mensagens via comandos no WhatsApp como !remind 30m Faça uma pausa."}
       ]
     })}
   </script>
@@ -31,8 +31,8 @@ import {RelatedGuides} from '@site/src/components/RelatedGuides';
     {JSON.stringify({
       "@context": "https://schema.org",
       "@type": "Article",
-      "headline": "How to Schedule WhatsApp Messages with Node.js",
-      "description": "Schedule WhatsApp messages to send at a specific time with Node.js — delayed sends, recurring reminders, and cron-based scheduling using whatsmeow-node.",
+      "headline": "Como Agendar Mensagens no WhatsApp com Node.js",
+      "description": "Agende mensagens no WhatsApp para enviar em um horário específico com Node.js — envios com delay, lembretes recorrentes e agendamento com cron usando whatsmeow-node.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/schedule-messages.png",
       "author": {"@type": "Organization", "name": "whatsmeow-node", "url": "https://nicastelo.github.io/whatsmeow-node/"},
       "publisher": {"@type": "Organization", "name": "whatsmeow-node", "logo": {"@type": "ImageObject", "url": "https://nicastelo.github.io/whatsmeow-node/img/image.png"}}

--- a/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/send-messages-typescript.md
+++ b/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/send-messages-typescript.md
@@ -16,15 +16,15 @@ import {RelatedGuides} from '@site/src/components/RelatedGuides';
     {JSON.stringify({
       "@context": "https://schema.org",
       "@type": "HowTo",
-      "name": "How to Send WhatsApp Messages from TypeScript",
-      "description": "Send WhatsApp messages from TypeScript with full type safety — text, replies, mentions, media, polls, and reactions using whatsmeow-node.",
+      "name": "Como Enviar Mensagens no WhatsApp com TypeScript",
+      "description": "Envie mensagens pelo WhatsApp com TypeScript e tipagem completa — texto, respostas, menções, mídia, enquetes e reações usando whatsmeow-node.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/send-messages-typescript.png",
       "step": [
-        {"@type": "HowToStep", "name": "Set Up the Client", "text": "Install whatsmeow-node and create a client with createClient(). Pair via QR code on first run."},
-        {"@type": "HowToStep", "name": "Send a Text Message", "text": "Use sendMessage(jid, { conversation: text }) for simple messages."},
-        {"@type": "HowToStep", "name": "Reply with Quotes and Mentions", "text": "Use sendRawMessage with extendedTextMessage and contextInfo for quoted replies and @mentions."},
-        {"@type": "HowToStep", "name": "Send Media Messages", "text": "Upload files with uploadMedia(), then send with sendRawMessage using the returned media metadata."},
-        {"@type": "HowToStep", "name": "React, Edit, and Delete", "text": "Use sendReaction(), editMessage(), and revokeMessage() to interact with sent messages."}
+        {"@type": "HowToStep", "name": "Configurar o Client", "text": "Instale o whatsmeow-node e crie um client com createClient(). Pareie via QR code na primeira execução."},
+        {"@type": "HowToStep", "name": "Enviar uma Mensagem de Texto", "text": "Use sendMessage(jid, { conversation: texto }) para mensagens simples."},
+        {"@type": "HowToStep", "name": "Responder com Citações e Menções", "text": "Use sendRawMessage com extendedTextMessage e contextInfo para respostas com citação e @menções."},
+        {"@type": "HowToStep", "name": "Enviar Mensagens de Mídia", "text": "Faça upload de arquivos com uploadMedia(), depois envie com sendRawMessage usando os metadados de mídia retornados."},
+        {"@type": "HowToStep", "name": "Reagir, Editar e Apagar", "text": "Use sendReaction(), editMessage() e revokeMessage() para interagir com mensagens enviadas."}
       ]
     })}
   </script>
@@ -32,8 +32,8 @@ import {RelatedGuides} from '@site/src/components/RelatedGuides';
     {JSON.stringify({
       "@context": "https://schema.org",
       "@type": "Article",
-      "headline": "How to Send WhatsApp Messages from TypeScript",
-      "description": "Send WhatsApp messages from TypeScript with full type safety — text, replies, mentions, media, polls, and reactions using whatsmeow-node.",
+      "headline": "Como Enviar Mensagens no WhatsApp com TypeScript",
+      "description": "Envie mensagens pelo WhatsApp com TypeScript e tipagem completa — texto, respostas, menções, mídia, enquetes e reações usando whatsmeow-node.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/send-messages-typescript.png",
       "author": {"@type": "Organization", "name": "whatsmeow-node", "url": "https://nicastelo.github.io/whatsmeow-node/"},
       "publisher": {"@type": "Organization", "name": "whatsmeow-node", "logo": {"@type": "ImageObject", "url": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/send-messages-typescript.png"}}

--- a/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/send-messages-typescript.md
+++ b/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/send-messages-typescript.md
@@ -1,0 +1,295 @@
+---
+title: "Como Enviar Mensagens no WhatsApp com TypeScript"
+sidebar_label: Enviar Mensagens (TypeScript)
+sidebar_position: 9
+description: "Envie mensagens pelo WhatsApp com TypeScript e tipagem completa — texto, respostas, menções, mídia, enquetes e reações usando whatsmeow-node."
+keywords: [enviar mensagem whatsapp typescript, whatsapp api typescript, whatsapp bot typescript, enviar texto whatsapp nodejs, whatsapp typescript biblioteca]
+---
+
+import Head from '@docusaurus/Head';
+import {RelatedGuides} from '@site/src/components/RelatedGuides';
+
+<Head>
+  <meta property="og:image" content="https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/send-messages-typescript.png" />
+  <meta name="twitter:image" content="https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/send-messages-typescript.png" />
+  <script type="application/ld+json">
+    {JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "HowTo",
+      "name": "How to Send WhatsApp Messages from TypeScript",
+      "description": "Send WhatsApp messages from TypeScript with full type safety — text, replies, mentions, media, polls, and reactions using whatsmeow-node.",
+      "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/send-messages-typescript.png",
+      "step": [
+        {"@type": "HowToStep", "name": "Set Up the Client", "text": "Install whatsmeow-node and create a client with createClient(). Pair via QR code on first run."},
+        {"@type": "HowToStep", "name": "Send a Text Message", "text": "Use sendMessage(jid, { conversation: text }) for simple messages."},
+        {"@type": "HowToStep", "name": "Reply with Quotes and Mentions", "text": "Use sendRawMessage with extendedTextMessage and contextInfo for quoted replies and @mentions."},
+        {"@type": "HowToStep", "name": "Send Media Messages", "text": "Upload files with uploadMedia(), then send with sendRawMessage using the returned media metadata."},
+        {"@type": "HowToStep", "name": "React, Edit, and Delete", "text": "Use sendReaction(), editMessage(), and revokeMessage() to interact with sent messages."}
+      ]
+    })}
+  </script>
+  <script type="application/ld+json">
+    {JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "Article",
+      "headline": "How to Send WhatsApp Messages from TypeScript",
+      "description": "Send WhatsApp messages from TypeScript with full type safety — text, replies, mentions, media, polls, and reactions using whatsmeow-node.",
+      "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/send-messages-typescript.png",
+      "author": {"@type": "Organization", "name": "whatsmeow-node", "url": "https://nicastelo.github.io/whatsmeow-node/"},
+      "publisher": {"@type": "Organization", "name": "whatsmeow-node", "logo": {"@type": "ImageObject", "url": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/send-messages-typescript.png"}}
+    })}
+  </script>
+</Head>
+
+![Como Enviar Mensagens no WhatsApp com TypeScript](/img/guides/pt-BR/send-messages-typescript.png)
+![Como Enviar Mensagens no WhatsApp com TypeScript](/img/guides/pt-BR/send-messages-typescript-light.png)
+
+# Como Enviar Mensagens no WhatsApp com TypeScript
+
+O whatsmeow-node oferece métodos async tipados para cada tipo de mensagem do WhatsApp — texto, respostas, menções, mídia, enquetes e reações. Este guia cobre cada um deles com exemplos em TypeScript.
+
+## Pré-requisitos
+
+- whatsmeow-node instalado ([Guia de instalação](/docs/installation))
+- Uma sessão pareada ([Como Parear o WhatsApp](pair-whatsapp))
+
+## Configurar o Client
+
+```typescript
+import { createClient } from "@whatsmeow-node/whatsmeow-node";
+
+const client = createClient({ store: "session.db" });
+
+async function main() {
+  const { jid: myJid } = await client.init();
+  if (!myJid) {
+    console.error("Not paired — run the pairing flow first");
+    process.exit(1);
+  }
+  await client.connect();
+  await client.waitForConnection();
+
+  const recipient = "5512345678@s.whatsapp.net";
+
+  // ... send messages here
+}
+
+main().catch(console.error);
+```
+
+## Enviar uma Mensagem de Texto
+
+A forma mais simples — passe uma string `conversation`:
+
+```typescript
+const resp = await client.sendMessage(recipient, {
+  conversation: "Hello from TypeScript!",
+});
+
+console.log(`Sent with ID: ${resp.id}`);
+```
+
+`sendMessage` é o método de alto nível. Ele recebe um JID e um objeto `MessageContent`, e retorna um `SendResponse` com o `id` e o `timestamp` da mensagem.
+
+## Responder com Citação
+
+Para mostrar a mensagem original em um balão de citação, use `sendRawMessage` com `contextInfo`:
+
+```typescript
+// Assume we received a message and have its info
+client.on("message", async ({ info, message }) => {
+  if (info.isFromMe) return;
+
+  const text =
+    (message.conversation as string) ??
+    (message.extendedTextMessage as { text?: string } | undefined)?.text;
+  if (!text) return;
+
+  await client.sendRawMessage(info.chat, {
+    extendedTextMessage: {
+      text: `You said: "${text}"`,
+      contextInfo: {
+        stanzaId: info.id,
+        participant: info.sender,
+        quotedMessage: { conversation: text },
+      },
+    },
+  });
+});
+```
+
+## Mencionar Usuários com @
+
+Inclua os JIDs em `mentionedJid` e use `@<número>` no texto:
+
+```typescript
+await client.sendRawMessage(groupJid, {
+  extendedTextMessage: {
+    text: `Hey @${memberJid.split("@")[0]}, check this out!`,
+    contextInfo: {
+      mentionedJid: [memberJid],
+    },
+  },
+});
+```
+
+Para mencionar todos em um grupo:
+
+```typescript
+const group = await client.getGroupInfo(groupJid);
+const jids = group.participants.map((p) => p.jid);
+const mentions = jids.map((j) => `@${j.split("@")[0]}`).join(" ");
+
+await client.sendRawMessage(groupJid, {
+  extendedTextMessage: {
+    text: `Attention: ${mentions}`,
+    contextInfo: { mentionedJid: jids },
+  },
+});
+```
+
+## Enviar Mídia
+
+Faça o upload primeiro, depois envie os metadados com uma raw message:
+
+```typescript
+// Upload an image
+const media = await client.uploadMedia("/path/to/photo.jpg", "image");
+
+await client.sendRawMessage(recipient, {
+  imageMessage: {
+    URL: media.URL,
+    directPath: media.directPath,
+    mediaKey: media.mediaKey,
+    fileEncSHA256: media.fileEncSHA256,
+    fileSHA256: media.fileSHA256,
+    fileLength: String(media.fileLength),
+    mimetype: "image/jpeg",
+    caption: "Check this out!",
+  },
+});
+```
+
+Outros tipos de mídia seguem o mesmo padrão — `videoMessage`, `audioMessage`, `documentMessage`, `stickerMessage`.
+
+:::warning Casing dos campos proto
+Os campos da resposta do upload usam o casing exato do protobuf: `URL`, `fileSHA256`, `fileEncSHA256` — **não** `url`, `fileSha256`. O casing errado falha silenciosamente.
+:::
+
+## Enviar uma Enquete
+
+```typescript
+const resp = await client.sendPollCreation(
+  groupJid,
+  "Where should we eat?",       // question
+  ["Pizza", "Sushi", "Tacos"],   // options
+  1,                              // max selectable
+);
+```
+
+## Reagir a uma Mensagem
+
+```typescript
+// Add a reaction
+await client.sendReaction(chat, senderJid, messageId, "🔥");
+
+// Remove a reaction (empty string)
+await client.sendReaction(chat, senderJid, messageId, "");
+```
+
+## Editar uma Mensagem Enviada
+
+```typescript
+const sent = await client.sendMessage(recipient, {
+  conversation: "Hello!",
+});
+
+// Edit it — only works on your own messages
+await client.editMessage(recipient, sent.id, {
+  conversation: "Hello! (edited)",
+});
+```
+
+## Apagar uma Mensagem
+
+```typescript
+// Revoke for everyone — only your own messages, within the time limit
+await client.revokeMessage(chat, myJid, sent.id);
+```
+
+## Marcar como Lida
+
+```typescript
+await client.markRead([info.id], info.chat, info.sender);
+```
+
+## Exemplo Completo
+
+Um bot que ecoa mensagens de texto como respostas com citação:
+
+```typescript
+import { createClient } from "@whatsmeow-node/whatsmeow-node";
+import qrcode from "qrcode-terminal";
+
+const client = createClient({ store: "session.db" });
+
+client.on("error", (err) => console.error("Error:", err));
+
+client.on("message", async ({ info, message }) => {
+  if (info.isFromMe) return;
+
+  const text =
+    (message.conversation as string) ??
+    (message.extendedTextMessage as { text?: string } | undefined)?.text;
+  if (!text) return;
+
+  await client.markRead([info.id], info.chat, info.sender);
+  await client.sendChatPresence(info.chat, "composing");
+
+  await client.sendRawMessage(info.chat, {
+    extendedTextMessage: {
+      text: `Echo: ${text}`,
+      contextInfo: {
+        stanzaId: info.id,
+        participant: info.sender,
+        quotedMessage: { conversation: text },
+      },
+    },
+  });
+});
+
+async function main() {
+  const { jid } = await client.init();
+  if (!jid) {
+    client.on("qr", ({ code }) => qrcode.generate(code, { small: true }));
+    await client.getQRChannel();
+  }
+  await client.connect();
+  console.log("Listening for messages...");
+
+  process.on("SIGINT", async () => {
+    await client.sendPresence("unavailable");
+    await client.disconnect();
+    client.close();
+    process.exit(0);
+  });
+}
+
+main().catch(console.error);
+```
+
+## Erros Comuns
+
+:::warning `sendMessage` vs `sendRawMessage`
+`sendMessage` é para texto simples. Para qualquer coisa estruturada (citações, menções, mídia), use `sendRawMessage` com o formato protobuf completo.
+:::
+
+:::warning Mensagens de grupo vão para `info.chat`
+Em grupos, sempre envie para `info.chat` (o JID do grupo), não para `info.sender` (o indivíduo). Enviar para `info.sender` inicia uma conversa privada.
+:::
+
+:::warning Rate limiting
+O WhatsApp limita a taxa de envio. Espaçe as mensagens, especialmente em grupos. Veja [Rate Limiting](/docs/rate-limiting) para detalhes.
+:::
+
+<RelatedGuides slugs={["build-a-bot", "automate-group-messages", "send-stickers", "send-notifications"]} />

--- a/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/send-notifications.md
+++ b/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/send-notifications.md
@@ -1,0 +1,271 @@
+---
+title: "Como Enviar Notificações pelo WhatsApp com Node.js"
+sidebar_label: Enviar Notificações
+sidebar_position: 17
+description: "Envie notificações, alertas e lembretes pelo WhatsApp com Node.js — atualizações de pedidos, lembretes de consultas, alertas do sistema e mais usando whatsmeow-node."
+keywords: [enviar notificação whatsapp nodejs, whatsapp notificação api, bot alerta whatsapp, bot lembrete whatsapp, enviar mensagem whatsapp programaticamente]
+---
+
+import Head from '@docusaurus/Head';
+import {RelatedGuides} from '@site/src/components/RelatedGuides';
+
+<Head>
+  <meta property="og:image" content="https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/send-notifications.png" />
+  <meta name="twitter:image" content="https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/send-notifications.png" />
+  <script type="application/ld+json">
+    {JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "HowTo",
+      "name": "How to Send WhatsApp Notifications from Node.js",
+      "description": "Send WhatsApp notifications, alerts, and reminders from Node.js — order updates, appointment reminders, system alerts, and more using whatsmeow-node.",
+      "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/send-notifications.png",
+      "step": [
+        {"@type": "HowToStep", "name": "Set Up the Client", "text": "Create a WhatsmeowClient, init, and connect. The client stays connected in the background."},
+        {"@type": "HowToStep", "name": "Send a Notification", "text": "Call sendMessage() with the recipient JID and a conversation message."},
+        {"@type": "HowToStep", "name": "Trigger from External Events", "text": "Call sendMessage from an HTTP endpoint, database trigger, or cron job."},
+        {"@type": "HowToStep", "name": "Send to Multiple Recipients", "text": "Iterate over a list of JIDs with a delay between sends to avoid rate limiting."}
+      ]
+    })}
+  </script>
+  <script type="application/ld+json">
+    {JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "Article",
+      "headline": "How to Send WhatsApp Notifications from Node.js",
+      "description": "Send WhatsApp notifications, alerts, and reminders from Node.js — order updates, appointment reminders, system alerts, and more using whatsmeow-node.",
+      "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/send-notifications.png",
+      "author": {"@type": "Organization", "name": "whatsmeow-node", "url": "https://nicastelo.github.io/whatsmeow-node/"},
+      "publisher": {"@type": "Organization", "name": "whatsmeow-node", "logo": {"@type": "ImageObject", "url": "https://nicastelo.github.io/whatsmeow-node/img/image.png"}}
+    })}
+  </script>
+</Head>
+
+![Como Enviar Notificações pelo WhatsApp com Node.js](/img/guides/pt-BR/send-notifications.png)
+![Como Enviar Notificações pelo WhatsApp com Node.js](/img/guides/pt-BR/send-notifications-light.png)
+
+# Como Enviar Notificações pelo WhatsApp com Node.js
+
+Envie alertas, lembretes e atualizações pelo WhatsApp a partir de qualquer app Node.js. O whatsmeow-node fica conectado em background — basta chamar `sendMessage()` sempre que precisar notificar alguém.
+
+## Pré-requisitos
+
+- Uma sessão pareada do whatsmeow-node ([Como Parear](pair-whatsapp))
+- O número de telefone do destinatário (como JID: `5512345678@s.whatsapp.net`)
+
+## Passo 1: Configurar uma Conexão Persistente
+
+```typescript
+import { createClient } from "@whatsmeow-node/whatsmeow-node";
+
+const client = createClient({ store: "session.db" });
+
+async function start() {
+  const { jid } = await client.init();
+  if (!jid) {
+    console.error("Not paired! See: How to Pair WhatsApp");
+    process.exit(1);
+  }
+  await client.connect();
+  await client.sendPresence("available");
+  console.log("Notification service is ready");
+}
+
+start().catch(console.error);
+```
+
+O client fica conectado e pronto para enviar mensagens a qualquer momento.
+
+## Passo 2: Enviar uma Notificação
+
+```typescript
+async function notify(phone: string, message: string) {
+  const jid = `${phone}@s.whatsapp.net`;
+  await client.sendMessage(jid, { conversation: message });
+}
+
+// Example: order update
+await notify("5512345678", "Your order #1234 has shipped! Track it at https://example.com/track/1234");
+```
+
+## Passo 3: Disparar a partir de um Endpoint HTTP
+
+Encapsule a notificação em uma rota Express para que outros serviços possam acioná-la:
+
+```typescript
+import express from "express";
+
+const app = express();
+app.use(express.json());
+
+app.post("/notify", async (req, res) => {
+  const { phone, message } = req.body;
+
+  if (!phone || !message) {
+    return res.status(400).json({ error: "phone and message are required" });
+  }
+
+  try {
+    const jid = `${phone}@s.whatsapp.net`;
+    const resp = await client.sendMessage(jid, { conversation: message });
+    res.json({ sent: true, id: resp.id });
+  } catch (err) {
+    res.status(500).json({ error: "Failed to send" });
+  }
+});
+
+app.listen(3000, () => console.log("Notification API on :3000"));
+```
+
+Agora qualquer serviço pode enviar uma notificação:
+
+```bash
+curl -X POST http://localhost:3000/notify \
+  -H "Content-Type: application/json" \
+  -d '{"phone": "5512345678", "message": "Your appointment is in 1 hour"}'
+```
+
+## Passo 4: Enviar para Múltiplos Destinatários
+
+```typescript
+async function broadcast(phones: string[], message: string) {
+  for (const phone of phones) {
+    const jid = `${phone}@s.whatsapp.net`;
+    await client.sendMessage(jid, { conversation: message });
+
+    // Wait between sends to avoid rate limiting
+    await new Promise((r) => setTimeout(r, 2000));
+  }
+}
+
+await broadcast(
+  ["5512345678", "5598765432", "5511223344"],
+  "Reminder: team meeting at 3 PM today",
+);
+```
+
+:::warning Rate limiting
+O WhatsApp limita a taxa de envio. Espaçe as mensagens de 1 a 3 segundos para envios em massa. Enviar rápido demais pode restringir temporariamente sua conta. Veja [Rate Limiting](/docs/rate-limiting).
+:::
+
+## Padrões de Notificação
+
+### Lembrete de consulta
+
+```typescript
+await notify(phone, `Reminder: your appointment with Dr. Smith is tomorrow at 10:00 AM.
+
+Reply CONFIRM to confirm or CANCEL to cancel.`);
+```
+
+### Atualização de pedido
+
+```typescript
+await notify(phone, `Order #${orderId} update: ${status}
+
+${status === "shipped" ? `Track: ${trackingUrl}` : ""}`);
+```
+
+### Alerta do sistema
+
+```typescript
+await notify(adminPhone, `⚠ Server alert: CPU usage at ${cpuPercent}% on ${hostname}`);
+```
+
+### Notificação para grupo
+
+```typescript
+// Send to a group instead of an individual
+const groupJid = "120363XXXXX@g.us";
+await client.sendMessage(groupJid, {
+  conversation: "Deploy complete: v2.1.0 is live",
+});
+```
+
+## Exemplo Completo
+
+Um serviço de notificações com API HTTP:
+
+```typescript
+import { createClient } from "@whatsmeow-node/whatsmeow-node";
+import express from "express";
+
+const client = createClient({ store: "session.db" });
+const app = express();
+app.use(express.json());
+
+app.post("/notify", async (req, res) => {
+  const { phone, message } = req.body;
+  if (!phone || !message) {
+    return res.status(400).json({ error: "phone and message are required" });
+  }
+
+  try {
+    const jid = `${phone}@s.whatsapp.net`;
+    const resp = await client.sendMessage(jid, { conversation: message });
+    res.json({ sent: true, id: resp.id });
+  } catch (err) {
+    console.error("Send failed:", err);
+    res.status(500).json({ error: "Failed to send" });
+  }
+});
+
+app.post("/broadcast", async (req, res) => {
+  const { phones, message } = req.body;
+  if (!phones?.length || !message) {
+    return res.status(400).json({ error: "phones[] and message are required" });
+  }
+
+  // Send in background
+  (async () => {
+    for (const phone of phones) {
+      try {
+        const jid = `${phone}@s.whatsapp.net`;
+        await client.sendMessage(jid, { conversation: message });
+      } catch (err) {
+        console.error(`Failed to send to ${phone}:`, err);
+      }
+      await new Promise((r) => setTimeout(r, 2000));
+    }
+    console.log(`Broadcast complete: ${phones.length} recipients`);
+  })();
+
+  res.json({ queued: true, count: phones.length });
+});
+
+async function main() {
+  const { jid } = await client.init();
+  if (!jid) {
+    console.error("Not paired!");
+    process.exit(1);
+  }
+  await client.connect();
+  await client.sendPresence("available");
+
+  app.listen(3000, () => console.log("Notification API on :3000"));
+
+  process.on("SIGINT", async () => {
+    await client.sendPresence("unavailable");
+    await client.disconnect();
+    client.close();
+    process.exit(0);
+  });
+}
+
+main().catch(console.error);
+```
+
+## Erros Comuns
+
+:::warning Não faça spam
+Enviar mensagens em massa não solicitadas viola os Termos de Serviço do WhatsApp e pode resultar no banimento da sua conta. Envie notificações apenas para usuários que optaram por recebê-las.
+:::
+
+:::warning Rate limiting
+Espaçe os envios com delay de 1 a 3 segundos. Veja [Rate Limiting](/docs/rate-limiting) para detalhes.
+:::
+
+:::warning Mantenha a conexão ativa
+O client precisa estar conectado para enviar mensagens. Se o processo encerrar, será necessário reconectar. Em produção, use um gerenciador de processos como PM2 ou rode como serviço systemd.
+:::
+
+<RelatedGuides slugs={["schedule-messages", "automate-group-messages", "build-a-bot"]} />

--- a/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/send-notifications.md
+++ b/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/send-notifications.md
@@ -16,14 +16,14 @@ import {RelatedGuides} from '@site/src/components/RelatedGuides';
     {JSON.stringify({
       "@context": "https://schema.org",
       "@type": "HowTo",
-      "name": "How to Send WhatsApp Notifications from Node.js",
-      "description": "Send WhatsApp notifications, alerts, and reminders from Node.js — order updates, appointment reminders, system alerts, and more using whatsmeow-node.",
+      "name": "Como Enviar Notificações pelo WhatsApp com Node.js",
+      "description": "Envie notificações, alertas e lembretes pelo WhatsApp com Node.js — atualizações de pedidos, lembretes de consultas, alertas do sistema e mais usando whatsmeow-node.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/send-notifications.png",
       "step": [
-        {"@type": "HowToStep", "name": "Set Up the Client", "text": "Create a WhatsmeowClient, init, and connect. The client stays connected in the background."},
-        {"@type": "HowToStep", "name": "Send a Notification", "text": "Call sendMessage() with the recipient JID and a conversation message."},
-        {"@type": "HowToStep", "name": "Trigger from External Events", "text": "Call sendMessage from an HTTP endpoint, database trigger, or cron job."},
-        {"@type": "HowToStep", "name": "Send to Multiple Recipients", "text": "Iterate over a list of JIDs with a delay between sends to avoid rate limiting."}
+        {"@type": "HowToStep", "name": "Configurar o Client", "text": "Crie um WhatsmeowClient, inicialize e conecte. O client fica conectado em background."},
+        {"@type": "HowToStep", "name": "Enviar uma Notificação", "text": "Chame sendMessage() com o JID do destinatário e uma mensagem de texto."},
+        {"@type": "HowToStep", "name": "Disparar a partir de Eventos Externos", "text": "Chame sendMessage a partir de um endpoint HTTP, trigger de banco de dados ou cron job."},
+        {"@type": "HowToStep", "name": "Enviar para Múltiplos Destinatários", "text": "Itere sobre uma lista de JIDs com um delay entre os envios para evitar rate limiting."}
       ]
     })}
   </script>
@@ -31,8 +31,8 @@ import {RelatedGuides} from '@site/src/components/RelatedGuides';
     {JSON.stringify({
       "@context": "https://schema.org",
       "@type": "Article",
-      "headline": "How to Send WhatsApp Notifications from Node.js",
-      "description": "Send WhatsApp notifications, alerts, and reminders from Node.js — order updates, appointment reminders, system alerts, and more using whatsmeow-node.",
+      "headline": "Como Enviar Notificações pelo WhatsApp com Node.js",
+      "description": "Envie notificações, alertas e lembretes pelo WhatsApp com Node.js — atualizações de pedidos, lembretes de consultas, alertas do sistema e mais usando whatsmeow-node.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/send-notifications.png",
       "author": {"@type": "Organization", "name": "whatsmeow-node", "url": "https://nicastelo.github.io/whatsmeow-node/"},
       "publisher": {"@type": "Organization", "name": "whatsmeow-node", "logo": {"@type": "ImageObject", "url": "https://nicastelo.github.io/whatsmeow-node/img/image.png"}}

--- a/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/send-stickers.md
+++ b/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/send-stickers.md
@@ -19,9 +19,9 @@ import Head from '@docusaurus/Head';
       "description": "Envie e receba stickers de WhatsApp programaticamente com Node.js — faça upload de arquivos WebP, defina dimensões e baixe stickers recebidos.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/send-stickers.png",
       "step": [
-        {"@type": "HowToStep", "name": "Upload the Sticker File", "text": "Use uploadMedia() with the WebP file path and 'image' media type."},
-        {"@type": "HowToStep", "name": "Send the Sticker Message", "text": "Use sendRawMessage with stickerMessage including width, height (512x512), and mimetype image/webp."},
-        {"@type": "HowToStep", "name": "Download Incoming Stickers", "text": "Listen for messages with stickerMessage and call downloadAny() to save to disk."}
+        {"@type": "HowToStep", "name": "Fazer Upload do Arquivo de Sticker", "text": "Use uploadMedia() com o caminho do arquivo WebP e o tipo de mídia 'image'."},
+        {"@type": "HowToStep", "name": "Enviar a Mensagem de Sticker", "text": "Use sendRawMessage com stickerMessage incluindo width, height (512x512) e mimetype image/webp."},
+        {"@type": "HowToStep", "name": "Baixar Stickers Recebidos", "text": "Escute mensagens com stickerMessage e chame downloadAny() para salvar no disco."}
       ]
     })}
   </script>

--- a/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/typing-indicators.md
+++ b/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/typing-indicators.md
@@ -19,11 +19,11 @@ import Head from '@docusaurus/Head';
       "description": "Mostre indicadores de digitação e gravação no WhatsApp com Node.js — controle o estado de composição, presença online e inscreva-se na digitação de outros.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/typing-indicators.png",
       "step": [
-        {"@type": "HowToStep", "name": "Show typing...", "text": "Call sendChatPresence(chatJid, 'composing') to show the typing indicator."},
-        {"@type": "HowToStep", "name": "Show recording audio...", "text": "Call sendChatPresence(chatJid, 'composing', 'audio') for the recording indicator."},
-        {"@type": "HowToStep", "name": "Clear the Indicator", "text": "Call sendChatPresence(chatJid, 'paused') to stop the indicator without sending a message."},
-        {"@type": "HowToStep", "name": "Set Online/Offline Status", "text": "Call sendPresence('available') before typing indicators work, and 'unavailable' when shutting down."},
-        {"@type": "HowToStep", "name": "Subscribe to Others' Typing", "text": "Call subscribePresence(jid) and listen for presence and chat_presence events."}
+        {"@type": "HowToStep", "name": "Mostrar digitando...", "text": "Chame sendChatPresence(chatJid, 'composing') para mostrar o indicador de digitação."},
+        {"@type": "HowToStep", "name": "Mostrar gravando áudio...", "text": "Chame sendChatPresence(chatJid, 'composing', 'audio') para o indicador de gravação."},
+        {"@type": "HowToStep", "name": "Limpar o Indicador", "text": "Chame sendChatPresence(chatJid, 'paused') para parar o indicador sem enviar uma mensagem."},
+        {"@type": "HowToStep", "name": "Definir Status Online/Offline", "text": "Chame sendPresence('available') antes de usar indicadores de digitação, e 'unavailable' ao encerrar."},
+        {"@type": "HowToStep", "name": "Inscrever-se na Digitação de Outros", "text": "Chame subscribePresence(jid) e escute os eventos presence e chat_presence."}
       ]
     })}
   </script>

--- a/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/whatsmeow-in-node.md
+++ b/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/whatsmeow-in-node.md
@@ -1,0 +1,221 @@
+---
+title: "Como Usar o whatsmeow no Node.js"
+sidebar_label: whatsmeow no Node.js
+sidebar_position: 8
+description: "Use o whatsmeow a partir do Node.js e TypeScript — instale o pacote npm, conecte ao WhatsApp, envie mensagens e trate eventos sem escrever Go."
+keywords: [whatsmeow nodejs, whatsmeow node, whatsmeow typescript, whatsmeow npm, usar whatsmeow em javascript]
+---
+
+import Head from '@docusaurus/Head';
+import {RelatedGuides} from '@site/src/components/RelatedGuides';
+
+<Head>
+  <meta property="og:image" content="https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/whatsmeow-in-node.png" />
+  <meta name="twitter:image" content="https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/whatsmeow-in-node.png" />
+  <script type="application/ld+json">
+    {JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "HowTo",
+      "name": "How to Use whatsmeow in Node.js",
+      "description": "Use whatsmeow from Node.js and TypeScript — install the npm package, connect to WhatsApp, send messages, and handle events without writing Go.",
+      "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/whatsmeow-in-node.png",
+      "step": [
+        {"@type": "HowToStep", "name": "Install whatsmeow-node", "text": "Run npm install @whatsmeow-node/whatsmeow-node to get the precompiled Go binary and TypeScript wrapper."},
+        {"@type": "HowToStep", "name": "Create a Client", "text": "Use createClient() with a store path. The Go binary is spawned and managed automatically."},
+        {"@type": "HowToStep", "name": "Connect to WhatsApp", "text": "Call init() to check for an existing session, then connect(). Pair via QR code on first run."},
+        {"@type": "HowToStep", "name": "Send Messages and Handle Events", "text": "Use typed async methods like sendMessage() and listen for events like message, connected, and group:info."}
+      ]
+    })}
+  </script>
+  <script type="application/ld+json">
+    {JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "Article",
+      "headline": "How to Use whatsmeow in Node.js",
+      "description": "Use whatsmeow from Node.js and TypeScript — install the npm package, connect to WhatsApp, send messages, and handle events without writing Go.",
+      "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/whatsmeow-in-node.png",
+      "author": {"@type": "Organization", "name": "whatsmeow-node", "url": "https://nicastelo.github.io/whatsmeow-node/"},
+      "publisher": {"@type": "Organization", "name": "whatsmeow-node", "logo": {"@type": "ImageObject", "url": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/whatsmeow-in-node.png"}}
+    })}
+  </script>
+</Head>
+
+![Como Usar o whatsmeow no Node.js](/img/guides/pt-BR/whatsmeow-in-node.png)
+![Como Usar o whatsmeow no Node.js](/img/guides/pt-BR/whatsmeow-in-node-light.png)
+
+# Como Usar o whatsmeow no Node.js
+
+[whatsmeow](https://github.com/tulir/whatsmeow) é a biblioteca Go mais testada em batalha para o protocolo multi-dispositivo do WhatsApp — ela alimenta a [Mautrix WhatsApp bridge](https://github.com/mautrix/whatsapp) usada por milhares de homeservers Matrix 24/7. O whatsmeow-node traz isso para o Node.js com métodos async tipados e uma API orientada a eventos, sem precisar configurar Go.
+
+## Como Funciona
+
+O whatsmeow-node inclui um binário Go pré-compilado para a sua plataforma (macOS, Linux, Windows). Quando você chama `createClient()`, ele inicia esse binário e se comunica via JSON-line IPC através de stdin/stdout:
+
+```
+Node.js (TypeScript) → stdin JSON → Go binary (whatsmeow) → WhatsApp
+                     ← stdout JSON ←
+```
+
+Você nunca interage com o binário diretamente. Cada método do whatsmeow é exposto como uma função async tipada no client.
+
+## Passo 1: Instalar
+
+```bash
+npm install @whatsmeow-node/whatsmeow-node
+```
+
+O binário correto para o seu SO e arquitetura é instalado automaticamente via dependência opcional.
+
+:::info
+Plataformas suportadas: macOS (arm64, x64), Linux (arm64, x64), Windows (x64). Veja [Instalação](/docs/installation) para detalhes.
+:::
+
+## Passo 2: Criar o Client
+
+```typescript
+import { createClient } from "@whatsmeow-node/whatsmeow-node";
+
+const client = createClient({ store: "session.db" });
+
+client.on("error", (err) => {
+  console.error("Error:", err);
+});
+```
+
+`store` é onde o whatsmeow persiste a sessão. Use um caminho de arquivo para SQLite (desenvolvimento) ou uma URI PostgreSQL para produção.
+
+## Passo 3: Conectar ao WhatsApp
+
+```typescript
+import qrcode from "qrcode-terminal";
+
+async function main() {
+  const { jid } = await client.init();
+
+  if (jid) {
+    // Já pareado — reconectar
+    console.log(`Resuming session for ${jid}`);
+    await client.connect();
+  } else {
+    // Primeira execução — parear via QR code
+    client.on("qr", ({ code }) => qrcode.generate(code, { small: true }));
+    await client.getQRChannel();
+    await client.connect();
+  }
+}
+
+main().catch(console.error);
+```
+
+Depois de escanear o QR code uma vez, a sessão é armazenada e as execuções seguintes vão direto para o `connect()`.
+
+## Passo 4: Enviar Mensagens e Tratar Eventos
+
+```typescript
+// Send a text message
+const jid = "5512345678@s.whatsapp.net";
+await client.sendMessage(jid, { conversation: "Hello from whatsmeow!" });
+
+// Listen for incoming messages
+client.on("message", async ({ info, message }) => {
+  if (info.isFromMe) return;
+
+  const text =
+    (message.conversation as string) ??
+    (message.extendedTextMessage as { text?: string } | undefined)?.text;
+
+  if (text) {
+    console.log(`${info.pushName}: ${text}`);
+  }
+});
+
+// Listen for group events
+client.on("group:info", (event) => {
+  if (event.join) console.log(`${event.join.join(", ")} joined ${event.jid}`);
+});
+```
+
+## O Que Está Disponível
+
+O whatsmeow-node encapsula mais de 100 métodos do whatsmeow. As principais áreas:
+
+| Categoria | Métodos |
+|----------|---------|
+| **Mensagens** | `sendMessage`, `sendRawMessage`, `editMessage`, `revokeMessage`, `sendReaction`, `markRead` |
+| **Mídia** | `uploadMedia`, `downloadAny`, `downloadMedia` |
+| **Grupos** | `createGroup`, `getJoinedGroups`, `getGroupInfo`, `updateGroupParticipants`, `setGroupAnnounce` |
+| **Presença** | `sendPresence`, `sendChatPresence`, `subscribePresence` |
+| **Privacidade** | `getPrivacySettings`, `setPrivacySetting`, `getBlocklist`, `updateBlocklist` |
+| **Enquetes** | `sendPollCreation`, `sendPollVote` |
+| **Newsletters** | `createNewsletter`, `getSubscribedNewsletters`, `followNewsletter` |
+
+Veja a [Referência da API](/docs/api/overview) para a lista completa.
+
+## Exemplo Completo
+
+```typescript
+import { createClient } from "@whatsmeow-node/whatsmeow-node";
+import qrcode from "qrcode-terminal";
+
+const client = createClient({ store: "session.db" });
+
+client.on("error", (err) => console.error("Error:", err));
+client.on("logged_out", ({ reason }) => {
+  console.error(`Logged out: ${reason}`);
+  client.close();
+  process.exit(1);
+});
+
+client.on("message", async ({ info, message }) => {
+  if (info.isFromMe) return;
+
+  const text =
+    (message.conversation as string) ??
+    (message.extendedTextMessage as { text?: string } | undefined)?.text;
+
+  if (text) {
+    console.log(`${info.pushName}: ${text}`);
+    await client.markRead([info.id], info.chat, info.sender);
+  }
+});
+
+async function main() {
+  const { jid } = await client.init();
+
+  if (jid) {
+    await client.connect();
+    console.log(`Connected as ${jid}`);
+  } else {
+    client.on("qr", ({ code }) => qrcode.generate(code, { small: true }));
+    await client.getQRChannel();
+    await client.connect();
+  }
+
+  await client.sendPresence("available");
+
+  process.on("SIGINT", async () => {
+    await client.sendPresence("unavailable");
+    await client.disconnect();
+    client.close();
+    process.exit(0);
+  });
+}
+
+main().catch(console.error);
+```
+
+## Erros Comuns
+
+:::warning Não precisa instalar Go
+Você não precisa instalar Go. O binário pré-compilado já vem incluído no pacote npm. Se você está tentando compilar o whatsmeow por conta própria, está complicando demais — apenas faça `npm install`.
+:::
+
+:::warning Formato de JID
+Os JIDs do WhatsApp seguem o formato `5512345678@s.whatsapp.net` (individual) ou `120363XXXXX@g.us` (grupo). Não inclua o prefixo `+`.
+:::
+
+:::warning Gerenciamento de sessão
+O banco de dados da sessão contém chaves de criptografia. Se você apagá-lo, precisará parear novamente. Em produção, faça backup ou use PostgreSQL.
+:::
+
+<RelatedGuides slugs={["pair-whatsapp", "build-a-bot", "send-messages-typescript", "migrate-from-baileys"]} />

--- a/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/whatsmeow-in-node.md
+++ b/docs-site/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/whatsmeow-in-node.md
@@ -16,14 +16,14 @@ import {RelatedGuides} from '@site/src/components/RelatedGuides';
     {JSON.stringify({
       "@context": "https://schema.org",
       "@type": "HowTo",
-      "name": "How to Use whatsmeow in Node.js",
-      "description": "Use whatsmeow from Node.js and TypeScript — install the npm package, connect to WhatsApp, send messages, and handle events without writing Go.",
+      "name": "Como Usar o whatsmeow no Node.js",
+      "description": "Use o whatsmeow a partir do Node.js e TypeScript — instale o pacote npm, conecte ao WhatsApp, envie mensagens e trate eventos sem escrever Go.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/whatsmeow-in-node.png",
       "step": [
-        {"@type": "HowToStep", "name": "Install whatsmeow-node", "text": "Run npm install @whatsmeow-node/whatsmeow-node to get the precompiled Go binary and TypeScript wrapper."},
-        {"@type": "HowToStep", "name": "Create a Client", "text": "Use createClient() with a store path. The Go binary is spawned and managed automatically."},
-        {"@type": "HowToStep", "name": "Connect to WhatsApp", "text": "Call init() to check for an existing session, then connect(). Pair via QR code on first run."},
-        {"@type": "HowToStep", "name": "Send Messages and Handle Events", "text": "Use typed async methods like sendMessage() and listen for events like message, connected, and group:info."}
+        {"@type": "HowToStep", "name": "Instalar o whatsmeow-node", "text": "Execute npm install @whatsmeow-node/whatsmeow-node para obter o binário Go pré-compilado e o wrapper TypeScript."},
+        {"@type": "HowToStep", "name": "Criar o Client", "text": "Use createClient() com um caminho de store. O binário Go é iniciado e gerenciado automaticamente."},
+        {"@type": "HowToStep", "name": "Conectar ao WhatsApp", "text": "Chame init() para verificar uma sessão existente, depois connect(). Pareie via QR code na primeira execução."},
+        {"@type": "HowToStep", "name": "Enviar Mensagens e Tratar Eventos", "text": "Use métodos async tipados como sendMessage() e escute eventos como message, connected e group:info."}
       ]
     })}
   </script>
@@ -31,8 +31,8 @@ import {RelatedGuides} from '@site/src/components/RelatedGuides';
     {JSON.stringify({
       "@context": "https://schema.org",
       "@type": "Article",
-      "headline": "How to Use whatsmeow in Node.js",
-      "description": "Use whatsmeow from Node.js and TypeScript — install the npm package, connect to WhatsApp, send messages, and handle events without writing Go.",
+      "headline": "Como Usar o whatsmeow no Node.js",
+      "description": "Use o whatsmeow a partir do Node.js e TypeScript — instale o pacote npm, conecte ao WhatsApp, envie mensagens e trate eventos sem escrever Go.",
       "image": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/whatsmeow-in-node.png",
       "author": {"@type": "Organization", "name": "whatsmeow-node", "url": "https://nicastelo.github.io/whatsmeow-node/"},
       "publisher": {"@type": "Organization", "name": "whatsmeow-node", "logo": {"@type": "ImageObject", "url": "https://nicastelo.github.io/whatsmeow-node/img/guides/pt-BR/whatsmeow-in-node.png"}}


### PR DESCRIPTION
## Summary

- **34 new translation files** (17 PT-BR + 17 ES)
- All 23 guides now have full translations across EN, PT-BR, and ES
- Hero image paths updated to locale-specific versions (`/img/guides/pt-BR/`, `/img/guides/es/`)
- Code blocks kept in English, prose and admonitions translated
- JSON-LD structured data kept in English for Google crawling

### Translated guides
whatsmeow-in-node, send-messages-typescript, migrate-from-baileys, migrate-from-whatsapp-web-js, automate-group-messages, connect-to-chatgpt, connect-to-gemini, connect-to-deepseek, connect-to-ollama, send-notifications, schedule-messages, poll-bot, forward-messages, integrate-whaticket, integrate-n8n, integrate-chatwoot, integrate-typebot

## Test plan

- [ ] `npx docusaurus build` passes for all 3 locales
- [ ] Switch to PT-BR — all 23 guides render with Portuguese content
- [ ] Switch to ES — all 23 guides render with Spanish content
- [ ] Hero images use locale-specific paths