### PR TITLE
Fix npm homepage URL to point to docs site

### DIFF
--- a/ts/package.json
+++ b/ts/package.json
@@ -40,7 +40,7 @@
     "url": "git+https://github.com/nicastelo/whatsmeow-node.git",
     "directory": "ts"
   },
-  "homepage": "https://github.com/nicastelo/whatsmeow-node#readme",
+  "homepage": "https://nicastelo.github.io/whatsmeow-node/",
   "bugs": {
     "url": "https://github.com/nicastelo/whatsmeow-node/issues"
   },


### PR DESCRIPTION
## Summary

- Update `homepage` in `ts/package.json` from GitHub repo URL to the docs site
- `https://github.com/nicastelo/whatsmeow-node#readme` → `https://nicastelo.github.io/whatsmeow-node/`

Takes effect on next npm publish.