### PR TITLE
Fix watch workflow: upstream diff + AI analysis

### DIFF
--- a/.github/workflows/whatsmeow-release-watch.yml
+++ b/.github/workflows/whatsmeow-release-watch.yml
@@ -39,6 +39,66 @@ jobs:
           echo "latest=$latest" >> "$GITHUB_OUTPUT"
           echo "has_update=$has_update" >> "$GITHUB_OUTPUT"
 
+      - name: Clone upstream and generate diff
+        if: steps.detect.outputs.has_update == 'true'
+        id: diff
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # Extract commit hashes from Go pseudo-versions
+          extract_hash() {
+            echo "$1" | sed -nE 's/^v[0-9.]+-[0-9]+-([0-9a-f]+)$/\1/p'
+          }
+
+          current_hash="$(extract_hash "${{ steps.detect.outputs.current }}")"
+          latest_hash="$(extract_hash "${{ steps.detect.outputs.latest }}")"
+
+          # Fall back to version string if not a pseudo-version
+          current_ref="${current_hash:-${{ steps.detect.outputs.current }}}"
+          latest_ref="${latest_hash:-${{ steps.detect.outputs.latest }}}"
+
+          echo "current_ref=$current_ref" >> "$GITHUB_OUTPUT"
+          echo "latest_ref=$latest_ref" >> "$GITHUB_OUTPUT"
+
+          # Clone upstream (shallow is enough for log/diff)
+          git clone --bare https://github.com/tulir/whatsmeow.git /tmp/whatsmeow-upstream
+
+          # Generate commit log
+          git -C /tmp/whatsmeow-upstream log \
+            --oneline --no-merges \
+            "${current_ref}..${latest_ref}" \
+            > upstream-commits.txt 2>/dev/null || echo "(could not generate commit log)" > upstream-commits.txt
+
+          commit_count="$(wc -l < upstream-commits.txt | tr -d ' ')"
+          echo "commit_count=$commit_count" >> "$GITHUB_OUTPUT"
+
+          # Generate diff (stat + patch, capped at 100KB for AI analysis)
+          git -C /tmp/whatsmeow-upstream diff \
+            "${current_ref}..${latest_ref}" \
+            --stat > upstream-diff-stat.txt 2>/dev/null || echo "(could not generate diff stat)" > upstream-diff-stat.txt
+
+          git -C /tmp/whatsmeow-upstream diff \
+            "${current_ref}..${latest_ref}" \
+            -- '*.go' ':!*_test.go' \
+            > upstream-diff-full.txt 2>/dev/null || echo "(could not generate diff)" > upstream-diff-full.txt
+
+          # Cap the diff at 80KB for AI input
+          head -c 81920 upstream-diff-full.txt > upstream-diff.txt
+
+          # Find matching upstream releases (by date range from pseudo-versions)
+          current_date="$(echo "${{ steps.detect.outputs.current }}" | sed -nE 's/^v[0-9.]+-([0-9]{8})[0-9]+-.*$/\1/p')"
+          latest_date="$(echo "${{ steps.detect.outputs.latest }}" | sed -nE 's/^v[0-9.]+-([0-9]{8})[0-9]+-.*$/\1/p')"
+
+          # List tags between the two commits
+          git -C /tmp/whatsmeow-upstream tag --contains "$current_ref" --no-contains "$latest_ref" \
+            > /dev/null 2>&1 || true
+          git -C /tmp/whatsmeow-upstream log \
+            --oneline --decorate=short \
+            "${current_ref}..${latest_ref}" \
+            | grep -oE 'tag: [^ ,)]+' | sed 's/tag: //' \
+            > upstream-tags.txt 2>/dev/null || touch upstream-tags.txt
+
       - name: Analyze update impact (parity + API changes)
         if: steps.detect.outputs.has_update == 'true'
         id: analyze
@@ -121,6 +181,62 @@ jobs:
           echo "parity_status=$parity_status" >> "$GITHUB_OUTPUT"
           echo "breaking=$breaking" >> "$GITHUB_OUTPUT"
 
+      - name: AI analysis of upstream diff
+        if: steps.detect.outputs.has_update == 'true'
+        id: ai
+        continue-on-error: true
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        shell: bash
+        run: |
+          if [ -z "$ANTHROPIC_API_KEY" ]; then
+            echo "AI analysis skipped: ANTHROPIC_API_KEY not set"
+            echo "_AI analysis skipped (no API key configured)._" > ai-summary.md
+            exit 0
+          fi
+
+          diff_content="$(cat upstream-diff.txt)"
+          commits="$(cat upstream-commits.txt)"
+          api_changes="$(cat api-change-summary.md)"
+
+          # Build the prompt
+          prompt="You are analyzing a Go library diff for whatsmeow (a WhatsApp Web protocol library).
+
+          We maintain whatsmeow-node, a Node.js/TypeScript binding that wraps whatsmeow via IPC.
+
+          Here are the commits between the current and latest versions:
+          ${commits}
+
+          Here is the API change summary (Client methods added/removed/changed):
+          ${api_changes}
+
+          Here is the actual code diff (non-test .go files only):
+          ${diff_content}
+
+          Please provide:
+          1. **Summary**: A concise summary of what changed (2-3 sentences)
+          2. **Impact on whatsmeow-node**: Do any of these changes affect our binding? New methods to wrap? Signature changes to update? Breaking changes?
+          3. **Risk assessment**: Low/Medium/High — how risky is upgrading?
+          4. **Action items**: Specific things we need to do before or after upgrading
+
+          Keep the response under 500 words. Use markdown formatting."
+
+          # Call Anthropic API
+          response="$(curl -s https://api.anthropic.com/v1/messages \
+            -H "content-type: application/json" \
+            -H "x-api-key: $ANTHROPIC_API_KEY" \
+            -H "anthropic-version: 2023-06-01" \
+            -d "$(jq -n \
+              --arg prompt "$prompt" \
+              '{
+                model: "claude-sonnet-4-20250514",
+                max_tokens: 1024,
+                messages: [{role: "user", content: $prompt}]
+              }')")"
+
+          # Extract the text response
+          echo "$response" | jq -r '.content[0].text // "AI analysis failed to generate a response."' > ai-summary.md
+
       - name: Build Go binary with new whatsmeow
         if: steps.detect.outputs.has_update == 'true'
         run: go build -o whatsmeow-node ./cmd/whatsmeow-node
@@ -172,6 +288,9 @@ jobs:
         env:
           CURRENT: ${{ steps.detect.outputs.current }}
           LATEST: ${{ steps.detect.outputs.latest }}
+          CURRENT_REF: ${{ steps.diff.outputs.current_ref }}
+          LATEST_REF: ${{ steps.diff.outputs.latest_ref }}
+          COMMIT_COUNT: ${{ steps.diff.outputs.commit_count }}
           PARITY_STATUS: ${{ steps.analyze.outputs.parity_status }}
           BREAKING: ${{ steps.analyze.outputs.breaking }}
           BUILD_STATUS: ${{ steps.build.outcome }}
@@ -183,129 +302,80 @@ jobs:
             const repo = context.repo.repo;
             const current = process.env.CURRENT;
             const latest = process.env.LATEST;
+            const currentRef = process.env.CURRENT_REF;
+            const latestRef = process.env.LATEST_REF;
+            const commitCount = process.env.COMMIT_COUNT || '0';
             const parityStatus = process.env.PARITY_STATUS || 'fail';
             const breaking = process.env.BREAKING || 'false';
             const buildStatus = process.env.BUILD_STATUS || 'skipped';
             const e2eStatus = process.env.E2E_STATUS || 'skipped';
             const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
-            const upstreamOwner = 'tulir';
-            const upstreamRepoName = 'whatsmeow';
             const upstreamRepo = 'https://github.com/tulir/whatsmeow';
-            const changelogUrl = `${upstreamRepo}/releases`;
-            const title = `[watch] whatsmeow update available: ${current} -> ${latest}`;
-
-            const toRef = (version) => {
-              const pseudo = /^v\d+\.\d+\.\d+-\d{14}-([0-9a-f]{12})$/;
-              const match = version.match(pseudo);
-              return match ? match[1] : version;
-            };
-            const currentRef = toRef(current);
-            const latestRef = toRef(latest);
             const compareUrl = `${upstreamRepo}/compare/${currentRef}...${latestRef}`;
             const latestVersionUrl = `https://pkg.go.dev/go.mau.fi/whatsmeow@${latest}`;
-            const latestSourceUrl = `${upstreamRepo}/tree/${latestRef}`;
+            const title = `[watch] whatsmeow update available: ${current} -> ${latest}`;
+
             const truncate = (text, max) => {
               if (!text) return '';
               return text.length > max ? `${text.slice(0, max)}\n\n...[truncated]...` : text;
             };
+            const readFile = (path) => {
+              try { return fs.readFileSync(path, 'utf8').trim(); }
+              catch { return ''; }
+            };
 
-            let parityOutput = 'No parity output captured.';
-            if (fs.existsSync('parity-output.txt')) {
-              parityOutput = fs.readFileSync('parity-output.txt', 'utf8').trim();
-            }
-
-            let e2eOutput = 'No E2E output captured.';
-            if (fs.existsSync('e2e-output.txt')) {
-              e2eOutput = fs.readFileSync('e2e-output.txt', 'utf8').trim();
-            }
-
-            let apiSummary = 'No API change summary captured.';
-            if (fs.existsSync('api-change-summary.md')) {
-              apiSummary = fs.readFileSync('api-change-summary.md', 'utf8').trim();
-            }
-
-            let releaseNotes = '';
-            let releaseTitle = '';
-            let releaseUrl = '';
-            try {
-              const releases = await github.rest.repos.listReleases({
-                owner: upstreamOwner,
-                repo: upstreamRepoName,
-                per_page: 100,
-              });
-              const matched = releases.data.find((rel) => rel.tag_name === latestRef);
-              if (matched) {
-                releaseTitle = matched.name || matched.tag_name;
-                releaseUrl = matched.html_url;
-                releaseNotes = truncate(matched.body || '', 6000);
-              }
-            } catch (err) {
-              core.warning(`Failed to fetch releases: ${String(err)}`);
-            }
-
-            let compareSummary = '';
-            try {
-              const compare = await github.rest.repos.compareCommits({
-                owner: upstreamOwner,
-                repo: upstreamRepoName,
-                basehead: `${currentRef}...${latestRef}`,
-              });
-              const commits = compare.data.commits || [];
-              const commitLines = commits
-                .slice(0, 30)
-                .map((c) => `- ${c.sha.slice(0, 12)} ${c.commit.message.split('\n')[0]}`);
-              const hidden = commits.length - commitLines.length;
-              if (hidden > 0) {
-                commitLines.push(`- ...and ${hidden} more commits`);
-              }
-              compareSummary = [
-                `Files changed: ${compare.data.files?.length ?? 0}`,
-                `Total commits: ${commits.length}`,
-                '',
-                ...commitLines,
-              ].join('\n');
-            } catch (err) {
-              core.warning(`Failed to fetch compare summary: ${String(err)}`);
-            }
+            const commits = readFile('upstream-commits.txt') || 'No commit log captured.';
+            const diffStat = readFile('upstream-diff-stat.txt') || 'No diff stat captured.';
+            const parityOutput = readFile('parity-output.txt') || 'No parity output captured.';
+            const e2eOutput = readFile('e2e-output.txt') || 'No E2E output captured.';
+            const apiSummary = readFile('api-change-summary.md') || 'No API change summary captured.';
+            const aiSummary = readFile('ai-summary.md') || '_No AI analysis available._';
 
             const body = [
               'A new `go.mau.fi/whatsmeow` version is available.',
               '',
               `- Current: \`${current}\``,
               `- Latest: \`${latest}\``,
-              `- Latest version link: ${latestVersionUrl}`,
-              `- Latest source link: ${latestSourceUrl}`,
-              `- Changelog / releases: ${changelogUrl}`,
-              `- Compare current -> latest: ${compareUrl}`,
-              `- Parity check against latest: **${parityStatus.toUpperCase()}**`,
-              `- Build with new version: **${buildStatus.toUpperCase()}**`,
-              `- E2E tests against new version: **${e2eStatus.toUpperCase()}**`,
-              `- Potential breaking API change detected: **${breaking.toUpperCase()}**`,
+              `- Go docs: ${latestVersionUrl}`,
+              `- Compare: ${compareUrl}`,
+              `- Commits: ${commitCount}`,
+              `- Parity check: **${parityStatus.toUpperCase()}**`,
+              `- Build: **${buildStatus.toUpperCase()}**`,
+              `- E2E tests: **${e2eStatus.toUpperCase()}**`,
+              `- Breaking API change: **${breaking.toUpperCase()}**`,
               `- Workflow run: ${runUrl}`,
               '',
-              '## Upstream Release Notes',
-              releaseTitle ? `Release: ${releaseTitle}` : 'Release: not found for this ref',
-              releaseUrl ? `URL: ${releaseUrl}` : '',
-              releaseNotes ? releaseNotes : '_No release notes found for this exact ref (likely pseudo-version); see compare summary below._',
+              '## AI Analysis',
               '',
-              '## Upstream Changelog / Commit Summary',
-              compareSummary ? `\`\`\`text\n${truncate(compareSummary, 4000)}\n\`\`\`` : '_Compare summary unavailable._',
+              aiSummary,
+              '',
+              '## Upstream Commits',
+              '',
+              '```text',
+              truncate(commits, 4000),
+              '```',
+              '',
+              '## Diff Stats',
+              '',
+              '```text',
+              truncate(diffStat, 4000),
+              '```',
               '',
               apiSummary,
               '',
               '## Parity Output',
+              '',
               '```text',
-              parityOutput,
+              truncate(parityOutput, 4000),
               '```',
               '',
               '## E2E Test Results',
+              '',
               `Status: **${e2eStatus.toUpperCase()}**`,
               '',
               '```text',
               truncate(e2eOutput, 4000),
               '```',
-              '',
-              'Next step: open a parity batch PR to wrap added methods and address any breaking signature changes.',
             ].join('\n');
 
             const { data: issues } = await github.rest.issues.listForRepo({


### PR DESCRIPTION
## Summary

The watch-whatsmeow workflow was failing silently on two sections:
- **Release notes**: "not found for this ref" — whatsmeow uses pseudo-versions, not tagged releases
- **Compare summary**: "unavailable" — GitHub's compare API can't resolve 12-char hash prefixes on external repos

### Fix
- **Clone upstream repo** directly and use `git log`/`git diff` between the two commit hashes — no more relying on GitHub's compare API
- **AI analysis**: Pipes the diff through the Anthropic API (Claude) to generate a summary of changes, impact on whatsmeow-node, risk assessment, and action items
- **Cleaner issue format**: commits, diff stats, API changes, AI summary, parity, E2E all in dedicated sections

### Requirements
- `ANTHROPIC_API_KEY` repo secret (optional — AI analysis is skipped gracefully if not set)

## Test plan
- [ ] Merge and trigger `workflow_dispatch` on the watch workflow
- [ ] Verify the tracking issue has: commit log, diff stats, AI summary
- [ ] Verify it works without `ANTHROPIC_API_KEY` (skips AI section)